### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/py_moodle/auth.py
+++ b/src/py_moodle/auth.py
@@ -160,7 +160,10 @@ class MoodleAuth:
             "_eventId": "submit",
         }
         if self.debug:
-            print(f"[DEBUG] POST {cas_login_url} payload={payload}")
+            redacted_payload = payload.copy()
+            if "password" in redacted_payload:
+                redacted_payload["password"] = "***REDACTED***"
+            print(f"[DEBUG] POST {cas_login_url} payload={redacted_payload}")
         # Keep session cookies in self.session
         resp = self.session.post(cas_login_url, data=payload, allow_redirects=False)
         if self.debug:


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/4](https://github.com/erseco/python-moodle/security/code-scanning/4)

To fix the problem, we should ensure that sensitive information (specifically, the password) is never logged, even in debug mode. The best way to do this is to redact or omit the password field from the payload before logging. We can create a shallow copy of the payload, replace the password value with a placeholder (e.g., `"***REDACTED***"`), and log this sanitized version instead. This change should be made only in the debug log statement on line 163 in the `_cas_login` method. No changes to functionality are required, and no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
