### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # ./.github/workflows/ci.yml
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/2](https://github.com/erseco/python-moodle/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply to specific jobs). Since the workflow only reads repository contents and does not need to write to issues, pull requests, or other resources, the minimal required permission is `contents: read`. This should be added at the root level, just below the `name` field and before the `on` field, to ensure all jobs inherit this least-privilege setting unless overridden.

No additional methods, imports, or definitions are needed—just a YAML block addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
