### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/py_moodle/auth.py
+++ b/src/py_moodle/auth.py
@@ -107,7 +107,10 @@ class MoodleAuth:
             "anchor": "",
         }
         if self.debug:
-            print(f"[DEBUG] POST {login_url} payload={payload}")
+            redacted_payload = payload.copy()
+            if "password" in redacted_payload:
+                redacted_payload["password"] = "***REDACTED***"
+            print(f"[DEBUG] POST {login_url} payload={redacted_payload}")
         resp = self.session.post(login_url, data=payload, allow_redirects=True)
         if self.debug:
             print(f"[DEBUG] Response {resp.status_code} {resp.url}")


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/3](https://github.com/erseco/python-moodle/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive information such as passwords. The best way to do this is to redact or omit the password field from the payload before logging it. We can create a copy of the payload dictionary with the password replaced by a placeholder (e.g., `"***REDACTED***"`), and log this redacted version instead. This change should be made only in the debug log statement on line 110, and does not require changing the actual payload sent to the server. No new imports are needed, as dictionary copying and manipulation are built-in Python features.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
