### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,15 @@
 # ./.github/workflows/docs.yml
 name: Docs
+permissions:
+  contents: read
 on:
   push:
     branches: [main]
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/1](https://github.com/erseco/python-moodle/security/code-scanning/1)

To fix the problem, we should explicitly set the `permissions` block in the workflow. The best practice is to set the most restrictive permissions at the workflow level (e.g., `contents: read`), and then override them at the job or step level if more permissions are needed. In this workflow, only the "Deploy to GitHub Pages" step (within the `build` job) requires `contents: write` to push to the `gh-pages` branch. Therefore, we should:

1. Add `permissions: contents: read` at the top level of the workflow (applies to all jobs by default).
2. Add `permissions: contents: write` to the `build` job, since the deployment step needs to push to the repository.

Alternatively, if you want to be even more restrictive, you could split the deployment into a separate job with elevated permissions, but for this workflow, setting it at the job level is sufficient.

**Files/regions to change:**  
- Add a `permissions` block at the top level (after `name:` and before `on:`).
- Optionally, add or override the `permissions` block at the `build` job level if you want to be explicit.

**Methods/imports/definitions needed:**  
- No imports or code changes are needed, just YAML configuration changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
