### PR TITLE
Feature: Retrive site information trough webservice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ docs:
 	mkdocs build --strict
 
 test-local: ensure-env
-	pytest --moodle-env local
+	python -m pytest --moodle-env local
 
 test-staging: ensure-env
-	pytest --moodle-env staging
+	python -m pytest --moodle-env staging
 
 test: upd test-local
 

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ docs:
 	mkdocs build --strict
 
 test-local: ensure-env
-	python -m pytest --moodle-env local
+	pytest --moodle-env local
 
 test-staging: ensure-env
-	python -m pytest --moodle-env staging
+	pytest --moodle-env staging
 
 test: upd test-local
 

--- a/src/py_moodle/cli/app.py
+++ b/src/py_moodle/cli/app.py
@@ -17,6 +17,7 @@ from . import (
     pages,
     resources,
     sections,
+    site,
     urls,
     users,
 )
@@ -61,6 +62,7 @@ app.add_typer(folders.app, name="folders")
 app.add_typer(pages.app, name="pages")
 app.add_typer(resources.app, name="resources")
 app.add_typer(urls.app, name="urls")
+app.add_typer(site.app, name="site")
 
 # ...and so on for each new command group you create.
 

--- a/src/py_moodle/cli/site.py
+++ b/src/py_moodle/cli/site.py
@@ -1,0 +1,54 @@
+"""Site commands for ``py-moodle``."""
+
+import json
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from py_moodle.session import MoodleSession
+from py_moodle.site import get_site_info
+
+app = typer.Typer(help="Get site information.")
+console = Console()
+
+
+@app.command("info")
+def info(
+    ctx: typer.Context,
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
+):
+    """Get site info."""
+    ms = MoodleSession.get(ctx.obj["env"])
+    site_info = get_site_info(ms)
+
+    if as_json:
+        # We need to handle the dataclasses in the site_info object
+        # to make them serializable.
+        class DataclassEncoder(json.JSONEncoder):
+            def default(self, o):
+                from dataclasses import asdict, is_dataclass
+
+                if is_dataclass(o):
+                    return asdict(o)
+                return super().default(o)
+
+        console.print(
+            json.dumps(site_info, indent=4, cls=DataclassEncoder, ensure_ascii=False)
+        )
+        return
+
+    table = Table(title="Site Info")
+    table.add_column("Property", style="cyan")
+    table.add_column("Value", style="magenta")
+
+    for key, value in site_info.__dict__.items():
+        if isinstance(value, list):
+            table.add_row(key, str(len(value)) + " items")
+        else:
+            table.add_row(key, str(value))
+
+    console.print(table)
+
+
+__all__ = ["app"]

--- a/src/py_moodle/session.py
+++ b/src/py_moodle/session.py
@@ -126,8 +126,16 @@ class MoodleSession:
             timeout=30,
         )
         response.raise_for_status()
-        # TODO: Add better error handling here
-        return response.json()
+        data = response.json()
+        # Check for Moodle-specific error response
+        if isinstance(data, dict) and (
+            "exception" in data or "errorcode" in data or "message" in data
+        ):
+            raise MoodleSessionError(
+                f"Moodle API error: {data.get('message', 'Unknown error')} "
+                f"(errorcode: {data.get('errorcode', 'N/A')}, exception: {data.get('exception', 'N/A')})"
+            )
+        return data
 
     # ------------- factory -------------
     @classmethod

--- a/src/py_moodle/site.py
+++ b/src/py_moodle/site.py
@@ -1,0 +1,75 @@
+"""Site information."""
+
+from dataclasses import dataclass
+from typing import List
+
+from py_moodle.session import MoodleSession
+
+
+@dataclass
+class SiteFunction:
+    """A dataclass to represent a function available in the Moodle site."""
+
+    name: str
+    version: str
+
+
+@dataclass
+class AdvancedFeature:
+    """A dataclass to represent an advanced feature available in the Moodle site."""
+
+    name: str
+    value: int
+
+
+@dataclass
+class SiteInfo:
+    """A dataclass to represent the site information."""
+
+    sitename: str
+    username: str
+    firstname: str
+    lastname: str
+    fullname: str
+    lang: str
+    userid: int
+    siteurl: str
+    userpictureurl: str
+    functions: List[SiteFunction]
+    downloadfiles: int
+    uploadfiles: int
+    release: str
+    version: str
+    mobilecssurl: str
+    advancedfeatures: List[AdvancedFeature]
+    usercanmanageownfiles: bool
+    userquota: int
+    usermaxuploadfilesize: int
+    userhomepage: int
+    userprivateaccesskey: str
+    siteid: int
+    sitecalendartype: str
+    usercalendartype: str
+    userissiteadmin: bool
+    theme: str
+    limitconcurrentlogins: int
+    policyagreed: int
+
+
+def get_site_info(session: MoodleSession) -> SiteInfo:
+    """Get site info.
+
+    Args:
+        session (MoodleSession): The Moodle session.
+
+    Returns:
+        SiteInfo: The site information.
+    """
+    response = session.call("core_webservice_get_site_info")
+    response["functions"] = [
+        SiteFunction(**function) for function in response["functions"]
+    ]
+    response["advancedfeatures"] = [
+        AdvancedFeature(**feature) for feature in response["advancedfeatures"]
+    ]
+    return SiteInfo(**response)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,40 @@
+"""Tests for the site module."""
+from py_moodle.session import MoodleSession
+from py_moodle.site import SiteInfo, get_site_info
+
+
+def test_get_site_info_real(request):
+    """Test get_site_info in a real environment."""
+    env = request.config.moodle_target.name
+    ms = MoodleSession.get(env)
+    site_info = get_site_info(ms)
+
+    assert isinstance(site_info, SiteInfo)
+    assert site_info.sitename is not None
+    assert site_info.username is not None
+    assert site_info.firstname is not None
+    assert site_info.lastname is not None
+    assert site_info.fullname is not None
+    assert site_info.lang is not None
+    assert site_info.userid is not None
+    assert site_info.siteurl is not None
+    assert site_info.userpictureurl is not None
+    assert site_info.functions is not None
+    assert site_info.downloadfiles is not None
+    assert site_info.uploadfiles is not None
+    assert site_info.release is not None
+    assert site_info.version is not None
+    assert site_info.mobilecssurl is not None
+    assert site_info.advancedfeatures is not None
+    assert site_info.usercanmanageownfiles is not None
+    assert site_info.userquota is not None
+    assert site_info.usermaxuploadfilesize is not None
+    assert site_info.userhomepage is not None
+    assert site_info.userprivateaccesskey is not None
+    assert site_info.siteid is not None
+    assert site_info.sitecalendartype is not None
+    assert site_info.usercalendartype is not None
+    assert site_info.userissiteadmin is not None
+    assert site_info.theme is not None
+    assert site_info.limitconcurrentlogins is not None
+    assert site_info.policyagreed is not None

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,4 +1,5 @@
 """Tests for the site module."""
+
 from py_moodle.session import MoodleSession
 from py_moodle.site import SiteInfo, get_site_info
 


### PR DESCRIPTION
This pull request adds a new "site" command group to the CLI, enabling users to fetch and display detailed Moodle site information. It introduces new data models for site details, extends the session API for generic webservice calls, and provides test coverage for the new functionality.

**New CLI feature: Site info commands**
* Added a new `site` command group to the CLI, allowing users to retrieve site information via `py-moodle site info`, with output available in both table and JSON formats (`src/py_moodle/cli/app.py`, `src/py_moodle/cli/site.py`). [[1]](diffhunk://#diff-e3b8aa174c561ff22fd66c703fd898cdd4bb5de8e8fe793d54a85bcc5492ef32R20) [[2]](diffhunk://#diff-e3b8aa174c561ff22fd66c703fd898cdd4bb5de8e8fe793d54a85bcc5492ef32R65) [[3]](diffhunk://#diff-82b976299187a58e9ba5b154ea9a8fb5878f6f60e9e530be0b9311cee50ecfdbR1-R54)

**Data modeling and API integration**
* Introduced new dataclasses (`SiteInfo`, `SiteFunction`, `AdvancedFeature`) to model the site information returned by the Moodle API, and implemented the `get_site_info` function to fetch and parse this data (`src/py_moodle/site.py`).

**Session API improvements**
* Added a generic `call` method to `MoodleSession` for making arbitrary Moodle webservice API calls, which is now used to implement site info retrieval (`src/py_moodle/session.py`). [[1]](diffhunk://#diff-c817d9f839b9eb9ce5fa31765e759aab445a4e9cb31848af9468145d517d207cL15-R17) [[2]](diffhunk://#diff-c817d9f839b9eb9ce5fa31765e759aab445a4e9cb31848af9468145d517d207cR101-R131)

**Testing**
* Added a test to verify that `get_site_info` correctly retrieves and parses site information from a real Moodle environment (`tests/test_site.py`).