### PR TITLE
Add parelized tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ docs:
 	mkdocs build --strict
 
 test-local: ensure-env
-	pytest --moodle-env local
+	pytest --moodle-env local -n auto
 
 test-staging: ensure-env
-	pytest --moodle-env staging
+	pytest --moodle-env staging -n auto
 
 test: upd test-local
 
@@ -63,8 +63,8 @@ help:
 	@echo "  docs               - Build documentation with mkdocs"
 	@echo ""
 	@echo "Testing:"
-	@echo "  test-local         - Run local tests using pytest with moodle-env=local"
-	@echo "  test-staging       - Run tests using moodle-env=staging"
+	@echo "  test-local         - Run local tests (in parallel) using pytest with moodle-env=local"
+	@echo "  test-staging       - Run tests using (in parallel) moodle-env=staging"
 	@echo "  test               - Start containers (detached) and run local tests"
 	@echo ""
 	@echo "  help               - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ help:
 	@echo ""
 	@echo "Testing:"
 	@echo "  test-local         - Run local tests (in parallel) using pytest with moodle-env=local"
-	@echo "  test-staging       - Run tests using (in parallel) moodle-env=staging"
+	@echo "  test-staging       - Run tests (in parallel) using moodle-env=staging"
 	@echo "  test               - Start containers (detached) and run local tests"
 	@echo ""
 	@echo "  help               - Show this help message"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,26 @@ dependencies = [
     "lxml",
     "python-dotenv",
     "typer[all]",
-    "rich==14.1.0",
+    "rich",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "flake8",
+    "flake8-docstrings",
+    "black",
+    "mypy",
+    "isort",
+    "mkdocs",
+    "mkdocstrings[python]",
+    "pymdown-extensions",
+    "mkdocs-material",
+    "mkdocs-autorefs",
+    "mkdocs-git-revision-date-localized-plugin",
+    "mkdocs-minify-plugin"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ rich
 # dev dependencies
 pytest
 pytest-cov
+pytest-xdist
 flake8
 flake8-docstrings
 black


### PR DESCRIPTION
This pull request introduces improvements to the testing workflow and development environment setup. The main changes are the addition of parallel test execution for local and staging environments, and the introduction of a dedicated set of optional development dependencies in `pyproject.toml` for easier setup. The help output in the `Makefile` is also updated to reflect these changes.

**Testing workflow improvements:**
* Enabled parallel execution of tests for both local and staging environments by adding the `-n auto` flag to the `pytest` commands in the `Makefile`.
* Updated the help section in the `Makefile` to indicate that tests are now run in parallel.

**Development environment setup:**
* Added a `[project.optional-dependencies]` section named `dev` in `pyproject.toml`, listing common development tools such as `pytest`, `flake8`, `black`, `mypy`, and documentation generators for easier developer onboarding and environment consistency.
* Removed the strict version pinning for `rich` in `pyproject.toml` to allow for greater flexibility in dependency management.