### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/src/py_moodle/auth.py
+++ b/src/py_moodle/auth.py
@@ -120,10 +120,9 @@ class MoodleAuth:
             "anchor": "",
         }
         if self.debug:
-            redacted_payload = payload.copy()
-            if "password" in redacted_payload:
-                redacted_payload["password"] = "***REDACTED***"
-            print(f"[DEBUG] POST {login_url} payload={redacted_payload}")
+            # Avoid logging sensitive information such as passwords.
+            # Log only non-sensitive fields for debugging.
+            print(f"[DEBUG] POST {login_url} with username={self.username}")
         resp = self.session.post(login_url, data=payload, allow_redirects=True)
         if self.debug:
             print(f"[DEBUG] Response {resp.status_code} {resp.url}")


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/6](https://github.com/erseco/python-moodle/security/code-scanning/6)

To fix the issue, we should ensure that no log entry ever includes the password (or other secrets), and ideally avoid logging any structure derived directly from tainted data. Instead of copying and redacting the full payload, we can log only non-sensitive fields and static information, such as the URL and username, which are not secrets. That way, the debug log still provides useful context while guaranteeing that the password is not even indirectly part of the logged object.

Concretely, in `src/py_moodle/auth.py` inside `_standard_login`, we will replace the current debug block that creates `redacted_payload` and logs `payload={redacted_payload}` with a simpler message that mentions only the login URL and the username. This removes any dependency on the `password` field and should satisfy CodeQL for all alert variants tied to this location. The tests in `tests/conftest.py` do not perform any logging of the password—they only pass it to `login`—so they do not need code changes for this specific “clear-text logging” issue.

No new imports or helper methods are needed; we will only adjust the existing `if self.debug:` block around line 122 in `src/py_moodle/auth.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
