### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/src/py_moodle/auth.py
+++ b/src/py_moodle/auth.py
@@ -178,9 +178,12 @@ class MoodleAuth:
             "_eventId": "submit",
         }
         if self.debug:
-            redacted_payload = payload.copy()
-            if "password" in redacted_payload:
-                redacted_payload["password"] = "***REDACTED***"
+            redacted_payload = {
+                "username": self.username,
+                "password": "***REDACTED***",
+                "execution": cas_id,
+                "_eventId": "submit",
+            }
             print(f"[DEBUG] POST {cas_login_url} payload={redacted_payload}")
         # Keep session cookies in self.session
         resp = self.session.post(cas_login_url, data=payload, allow_redirects=False)


### PR DESCRIPTION
Potential fix for [https://github.com/erseco/python-moodle/security/code-scanning/5](https://github.com/erseco/python-moodle/security/code-scanning/5)

In general, to fix clear-text logging of sensitive information, you should ensure that any data structures logged do not contain secrets (passwords, tokens, etc.). Instead of copying and mutating a dict that was built with sensitive data, construct a separate redacted structure or log only selected non-sensitive fields.

In this case, the best fix with minimal behavior change is to avoid copying the tainted `payload` dict when logging and instead build a separate `redacted_payload` that includes only the non-sensitive fields (`username`, `execution`, `_eventId`) plus a fixed redacted placeholder for `password`. This keeps debugging usefulness (you still see what is being sent structurally) while guaranteeing that the original password value never flows into the logged object. We only need to adjust the `_cas_login` method in `src/py_moodle/auth.py`; the existing imports remain sufficient, and no helper methods are required.

Concretely:
- In `MoodleAuth._cas_login`, replace:

```python
if self.debug:
    redacted_payload = payload.copy()
    if "password" in redacted_payload:
        redacted_payload["password"] = "***REDACTED***"
    print(f"[DEBUG] POST {cas_login_url} payload={redacted_payload}")
```

with code that constructs `redacted_payload` from scratch, e.g.:

```python
if self.debug:
    redacted_payload = {
        "username": self.username,
        "password": "***REDACTED***",
        "execution": cas_id,
        "_eventId": payload.get("_eventId"),
    }
    print(f"[DEBUG] POST {cas_login_url} payload={redacted_payload}")
```

or equivalently just log a subset of fields, as long as the password never appears. No changes are needed in `tests/conftest.py`, since the leakage occurs in the `auth` module’s logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
