### PR TITLE
Remove input()/print() calls from core library, use exceptions and logging

### DIFF
--- a/src/py_moodle/auth.py
+++ b/src/py_moodle/auth.py
@@ -5,12 +5,15 @@ Authentication module for Moodle.
 Handles session-based login (including support for CAS) and retrieves the session key required for further AJAX requests.
 """
 
+import logging
 import re
 from typing import Optional
 
 import requests
 
 from .compat import DEFAULT_COMPATIBILITY, detect_moodle_compatibility
+
+logger = logging.getLogger("py_moodle.auth")
 
 
 class LoginError(Exception):
@@ -64,8 +67,8 @@ class MoodleAuth:
             LoginError: If authentication fails.
         """
         if self.debug:
-            print(
-                f"[DEBUG] Login: base_url={self.base_url} username={self.username} use_cas={self.use_cas} cas_url={self.cas_url}"
+            logger.debug(
+                f"Login: base_url={self.base_url} username={self.username} use_cas={self.use_cas} cas_url={self.cas_url}"
             )
         if self.use_cas and self.cas_url:
             self._cas_login()
@@ -75,19 +78,19 @@ class MoodleAuth:
         try:
             self.sesskey = self._get_sesskey()
             if self.debug:
-                print(f"[DEBUG] sesskey obtained: {self.sesskey}")
+                logger.debug(f"sesskey obtained: {self.sesskey}")
         except Exception as e:
             if self.debug:
-                print(f"[DEBUG] Could not obtain sesskey: {e}")
+                logger.debug(f"Could not obtain sesskey: {e}")
             self.sesskey = None
         # Try to get webservice token
         try:
             self.webservice_token = self._get_webservice_token()
             if self.debug:
-                print(f"[DEBUG] webservice_token obtained: {self.webservice_token}")
+                logger.debug(f"webservice_token obtained: {self.webservice_token}")
         except Exception as e:
             if self.debug:
-                print(f"[DEBUG] Could not obtain webservice token: {e}")
+                logger.debug(f"Could not obtain webservice token: {e}")
             self.webservice_token = None
         compatibility_context = detect_moodle_compatibility(
             self.session, self.base_url, token=self.webservice_token
@@ -95,8 +98,8 @@ class MoodleAuth:
         self.compatibility = compatibility_context.strategy
         self.moodle_version = compatibility_context.version
         if self.debug:
-            print(
-                "[DEBUG] Moodle compatibility:"
+            logger.debug(
+                "Moodle compatibility:"
                 f" version={self.moodle_version.raw}"
                 f" source={self.moodle_version.source}"
                 f" strategy={self.compatibility.version_range}"
@@ -107,10 +110,10 @@ class MoodleAuth:
         """Perform standard Moodle login and set session cookies."""
         login_url = f"{self.base_url}/login/index.php"
         if self.debug:
-            print(f"[DEBUG] GET {login_url}")
+            logger.debug(f"GET {login_url}")
         resp = self.session.get(login_url)
         if self.debug:
-            print(f"[DEBUG] Response {resp.status_code} {resp.url}")
+            logger.debug(f"Response {resp.status_code} {resp.url}")
         logintoken = self.compatibility.extract_login_token(resp.text)
 
         payload = {
@@ -122,10 +125,10 @@ class MoodleAuth:
         if self.debug:
             # Avoid logging sensitive information such as passwords.
             # Log only non-sensitive fields for debugging.
-            print(f"[DEBUG] POST {login_url} with username={self.username}")
+            logger.debug(f"POST {login_url} with username={self.username}")
         resp = self.session.post(login_url, data=payload, allow_redirects=True)
         if self.debug:
-            print(f"[DEBUG] Response {resp.status_code} {resp.url}")
+            logger.debug(f"Response {resp.status_code} {resp.url}")
         # Authentication failed if redirected back to login page
         if "/login/index.php" in resp.url or "Invalid login" in resp.text:
             raise LoginError(
@@ -145,11 +148,11 @@ class MoodleAuth:
 
         cas_login_url = f"{self.cas_url.rstrip('/')}/login?service={quote(service_url)}"
         if self.debug:
-            print(f"[DEBUG] GET {cas_login_url}")
+            logger.debug(f"GET {cas_login_url}")
         resp = self.session.get(cas_login_url)
         if self.debug:
-            print(f"[DEBUG] Response {resp.status_code} {resp.url}")
-            print(f"[DEBUG] Response text (first 500 chars): {resp.text[:500]}")
+            logger.debug(f"Response {resp.status_code} {resp.url}")
+            logger.debug(f"Response text (first 500 chars): {resp.text[:500]}")
         if resp.status_code != 200:
             raise LoginError(f"Failed to load CAS login page: {resp.status_code}")
         # Try to match both single and double quotes for value
@@ -163,11 +166,11 @@ class MoodleAuth:
             )
         if not cas_id_match:
             if self.debug:
-                print("[DEBUG] Could not find execution value in CAS login page.")
+                logger.debug("Could not find execution value in CAS login page.")
             raise LoginError("CAS login ticket not found (no execution value).")
         cas_id = cas_id_match.group(1)
         if self.debug:
-            print(f"[DEBUG] CAS execution value: {cas_id}")
+            logger.debug(f"CAS execution value: {cas_id}")
 
         # Step 2: Submit login form with username, password, execution
         payload = {
@@ -183,12 +186,12 @@ class MoodleAuth:
                 "execution": cas_id,
                 "_eventId": "submit",
             }
-            print(f"[DEBUG] POST {cas_login_url} payload={redacted_payload}")
+            logger.debug(f"POST {cas_login_url} payload={redacted_payload}")
         # Keep session cookies in self.session
         resp = self.session.post(cas_login_url, data=payload, allow_redirects=False)
         if self.debug:
-            print(f"[DEBUG] Response {resp.status_code} {resp.url}")
-            print(f"[DEBUG] Response headers: {resp.headers}")
+            logger.debug(f"Response {resp.status_code} {resp.url}")
+            logger.debug(f"Response headers: {resp.headers}")
         if resp.status_code not in (302, 303):
             raise LoginError(
                 f"CAS login POST did not redirect. Status: {resp.status_code}"
@@ -196,23 +199,23 @@ class MoodleAuth:
         location = resp.headers.get("Location")
         if not location:
             if self.debug:
-                print("[DEBUG] No Location header after CAS POST.")
+                logger.debug("No Location header after CAS POST.")
             raise LoginError("CAS login failed. No redirect to service with ticket.")
         if self.debug:
-            print(f"[DEBUG] Following redirect to {location}")
+            logger.debug(f"Following redirect to {location}")
         # Step 3: Follow redirect to Moodle with CAS ticket (keeping cookies)
         resp2 = self.session.get(location, allow_redirects=True)
         if self.debug:
-            print(f"[DEBUG] Response {resp2.status_code} {resp2.url}")
+            logger.debug(f"Response {resp2.status_code} {resp2.url}")
         # Optionally, check if login was successful
         dashboard_url = f"{self.base_url}/my/"
         if self.debug:
-            print(f"[DEBUG] GET {dashboard_url}")
+            logger.debug(f"GET {dashboard_url}")
         resp3 = self.session.get(dashboard_url)
         if self.debug:
-            print(f"[DEBUG] Dashboard response {resp3.status_code} {resp3.url}")
-            print(
-                f"[DEBUG] Dashboard response text (first 500 chars): {resp3.text[:500]}"
+            logger.debug(f"Dashboard response {resp3.status_code} {resp3.url}")
+            logger.debug(
+                f"Dashboard response text (first 500 chars): {resp3.text[:500]}"
             )
         # Relaxed check: if we get a 200 and the page is not the login form, consider it successful
         if resp3.status_code != 200:
@@ -257,7 +260,7 @@ class MoodleAuth:
         # Prefer a pre-configured token when provided.
         if self.pre_configured_token:
             if self.debug:
-                print("[DEBUG] Using pre-configured webservice token.")
+                logger.debug("Using pre-configured webservice token.")
             return self.pre_configured_token
 
         # This will only work if the user has a valid webservice enabled for 'moodle_mobile_app'
@@ -293,7 +296,7 @@ def enable_webservice(
         base_url: The base URL of the Moodle instance.
         sesskey: The session key for form submissions.
         service_id: The ID of the webservice to enable (default is 1 for 'Moodle mobile web service').
-        debug: If True, print debug information.
+        debug: If True, log debug information via ``logging.getLogger("py_moodle.auth")``.
 
     Returns:
         True if the operation seems successful.
@@ -314,11 +317,9 @@ def enable_webservice(
     resp = session.post(url, data=data)
 
     if debug:
-        print(f"[DEBUG] POST {url} -> {resp.status_code}")
+        logger.debug(f"POST {url} -> {resp.status_code}")
         if resp.status_code != 200:
-            print(f"[DEBUG] Response text (first 500 chars): {resp.text[:500]}")
-
-    # print(resp.text)
+            logger.debug(f"Response text (first 500 chars): {resp.text[:500]}")
 
     if resp.status_code != 200:
         raise LoginError(

--- a/src/py_moodle/cli/courses.py
+++ b/src/py_moodle/cli/courses.py
@@ -6,6 +6,7 @@ from rich.table import Table
 
 from py_moodle.cli.output import OutputFormat, emit
 from py_moodle.course import (
+    ConfirmationRequired,
     MoodleCourseError,
     create_course,
     delete_course,
@@ -179,6 +180,20 @@ def delete_a_course(
     try:
         delete_course(ms.session, ms.settings.url, ms.sesskey, course_id, force=force)
         typer.echo(f"Course {course_id} deleted successfully.")
+    except ConfirmationRequired as e:
+        confirm = typer.confirm(
+            f"Are you sure you want to delete course '{e.course_title}' "
+            f"(ID {e.course_id})?",
+            default=False,
+        )
+        if not confirm:
+            typer.echo("Aborted.")
+            raise typer.Exit(0)
+        delete_course(ms.session, ms.settings.url, ms.sesskey, course_id, force=True)
+        typer.echo(f"Course {course_id} deleted successfully.")
+    except MoodleCourseError as e:
+        typer.echo(f"Error deleting course: {e}", err=True)
+        raise typer.Exit(1)
     except Exception as e:
         typer.echo(f"Error deleting course: {e}", err=True)
         raise typer.Exit(1)

--- a/src/py_moodle/course.py
+++ b/src/py_moodle/course.py
@@ -21,6 +21,28 @@ class MoodleCourseError(Exception):
     """Exception raised for errors in course operations."""
 
 
+class ConfirmationRequired(MoodleCourseError):
+    """Raised when a mutating operation needs interactive confirmation.
+
+    Attributes:
+        course_id: The course id pending confirmation.
+        course_title: The human-readable title, if it could be determined.
+    """
+
+    def __init__(self, course_id: int, course_title: str) -> None:
+        """Initialize the exception with the pending course id and title.
+
+        Args:
+            course_id: The course id pending confirmation.
+            course_title: The human-readable title, if it could be determined.
+        """
+        self.course_id = course_id
+        self.course_title = course_title
+        super().__init__(
+            f"Confirmation required to delete course '{course_title}' (ID {course_id})."
+        )
+
+
 def get_course_context_id(
     session: requests.Session,
     base_url: str,
@@ -377,6 +399,10 @@ def delete_course(
 
     Raises:
         MoodleCourseError: If the request fails.
+        ConfirmationRequired: If ``force`` is ``False``. Callers must catch
+            this exception and re-invoke with ``force=True`` after obtaining
+            confirmation themselves; this function performs no stdin/stdout
+            I/O of its own.
     """
     import re
 
@@ -400,14 +426,9 @@ def delete_course(
     if not delete_token:
         raise MoodleCourseError("Could not find delete token in confirmation form.")
 
-    # If not forced, ask for interactive confirmation
+    # If not forced, the caller must confirm before we proceed.
     if not force:
-        confirm = input(
-            f"Are you sure you want to delete course '{course_title}' (ID {courseid})? [y/N]: "
-        )
-        if confirm.strip().lower() not in ("y", "yes"):
-            print("Aborted.")
-            return
+        raise ConfirmationRequired(courseid, course_title)
 
     # Step 2: send the confirmation form
     payload = {
@@ -623,6 +644,7 @@ def list_sections(course_contents: List[Dict[str, Any]]) -> List[Dict[str, Any]]
 
 __all__ = [
     "MoodleCourseError",
+    "ConfirmationRequired",
     "get_course_context_id",
     "list_courses",
     "create_course",

--- a/src/py_moodle/draftfile.py
+++ b/src/py_moodle/draftfile.py
@@ -9,6 +9,7 @@ All code and comments must be in English.
 """
 
 import json
+import logging
 import mimetypes
 import re
 import time
@@ -21,6 +22,8 @@ from py_moodle.module import MoodleModuleError
 
 from .config import DEFAULT_LARGE_UPLOAD_TIMEOUT, DEFAULT_REQUEST_TIMEOUT
 from .upload import ProgressTracker
+
+logger = logging.getLogger("py_moodle.draftfile")
 
 
 class MoodleDraftFileError(Exception):
@@ -189,7 +192,7 @@ def upload_file_to_draft_area(
 
     except (MoodleDraftFileError, MoodleModuleError) as e:
         # If detection fails, warn and fall back to 5 as a last resort
-        print(
+        logger.warning(
             f"Warning: Could not auto-detect repo_id ({e}). Falling back to default ID 5."
         )
         repo_id = 5  # '5' is typically the "Upload a file" repository

--- a/tests/unit/test_auth_logging.py
+++ b/tests/unit/test_auth_logging.py
@@ -1,0 +1,88 @@
+"""Unit tests for the logging-based debug output of ``py_moodle.auth``."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from py_moodle.auth import MoodleAuth
+
+
+def test_cas_login_logs_via_logging_and_redacts_password(caplog, capsys):
+    """CAS login should log via ``logging``, redacting the password, not print()."""
+    auth = MoodleAuth(
+        base_url="https://moodle.example.test",
+        username="user",
+        password="super-secret-pw",
+        use_cas=True,
+        cas_url="https://cas.example.test",
+        debug=True,
+    )
+
+    login_page_resp = MagicMock(
+        status_code=200,
+        text='<input name="execution" value="exec-token-123">',
+    )
+    post_resp = MagicMock(
+        status_code=302,
+        headers={"Location": "https://moodle.example.test/login/index.php?ticket=ST-1"},
+    )
+    redirect_resp = MagicMock(status_code=200, text="<html></html>")
+    dashboard_resp = MagicMock(status_code=200, text="<html>Dashboard</html>")
+
+    session = MagicMock()
+    session.get.side_effect = [login_page_resp, redirect_resp, dashboard_resp]
+    session.post.return_value = post_resp
+    auth.session = session
+
+    with caplog.at_level(logging.DEBUG, logger="py_moodle.auth"):
+        auth._cas_login()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    assert "super-secret-pw" not in caplog.text
+    assert "REDACTED" in caplog.text
+    assert any(record.name == "py_moodle.auth" for record in caplog.records)
+
+
+def test_login_debug_logs_sesskey_obtained_via_logging(monkeypatch, caplog, capsys):
+    """login() should log the obtained sesskey via logging, never via print()."""
+    auth = MoodleAuth(
+        base_url="https://moodle.example.test",
+        username="user",
+        password="pw",
+        debug=True,
+    )
+    monkeypatch.setattr(auth, "_standard_login", lambda: None)
+    monkeypatch.setattr(auth, "_get_sesskey", lambda: "sesskey-abc")
+    monkeypatch.setattr(auth, "_get_webservice_token", lambda: None)
+    monkeypatch.setattr(
+        "py_moodle.auth.detect_moodle_compatibility",
+        lambda session, base_url, token=None: SimpleNamespace(
+            strategy=SimpleNamespace(version_range="generic"),
+            version=SimpleNamespace(raw="4.1", source="test"),
+        ),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="py_moodle.auth"):
+        auth.login()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    messages = [
+        record.message for record in caplog.records if record.name == "py_moodle.auth"
+    ]
+    assert any("sesskey obtained: sesskey-abc" in message for message in messages)
+
+
+def test_auth_module_has_no_print_calls():
+    """The auth module source must contain zero ``print(`` calls."""
+    import inspect
+
+    import py_moodle.auth as auth_module
+
+    source = inspect.getsource(auth_module)
+    assert "print(" not in source

--- a/tests/unit/test_cli_courses_delete.py
+++ b/tests/unit/test_cli_courses_delete.py
@@ -1,0 +1,90 @@
+"""Unit tests for the interactive confirmation flow of ``courses delete``."""
+
+from unittest.mock import MagicMock, call, patch
+
+from typer.testing import CliRunner
+
+from py_moodle.cli.app import app
+from py_moodle.course import ConfirmationRequired
+
+runner = CliRunner()
+
+
+def _fake_moodle_session():
+    """Build a MagicMock standing in for a MoodleSession instance."""
+    ms = MagicMock()
+    ms.session = MagicMock()
+    ms.settings.url = "https://moodle.example.test"
+    ms.sesskey = "sesskey123"
+    return ms
+
+
+def test_delete_course_confirmation_declined_aborts_without_deleting():
+    """Declining the confirmation prompt aborts without a second delete call."""
+    fake_ms = _fake_moodle_session()
+    with (
+        patch("py_moodle.cli.courses.MoodleSession.get", return_value=fake_ms),
+        patch("py_moodle.cli.courses.delete_course") as mock_delete,
+    ):
+        mock_delete.side_effect = ConfirmationRequired(42, "Test Course")
+
+        result = runner.invoke(app, ["courses", "delete", "42"], input="n\n")
+
+    assert result.exit_code == 0
+    assert "Aborted." in result.output
+    assert "deleted successfully" not in result.output
+    mock_delete.assert_called_once_with(
+        fake_ms.session, fake_ms.settings.url, fake_ms.sesskey, 42, force=False
+    )
+
+
+def test_delete_course_confirmation_accepted_deletes():
+    """Accepting the confirmation prompt re-invokes delete_course(force=True)."""
+    fake_ms = _fake_moodle_session()
+    with (
+        patch("py_moodle.cli.courses.MoodleSession.get", return_value=fake_ms),
+        patch("py_moodle.cli.courses.delete_course") as mock_delete,
+    ):
+        mock_delete.side_effect = [ConfirmationRequired(42, "Test Course"), None]
+
+        result = runner.invoke(app, ["courses", "delete", "42"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Course 42 deleted successfully." in result.output
+    assert mock_delete.call_count == 2
+    mock_delete.assert_has_calls(
+        [
+            call(
+                fake_ms.session,
+                fake_ms.settings.url,
+                fake_ms.sesskey,
+                42,
+                force=False,
+            ),
+            call(
+                fake_ms.session,
+                fake_ms.settings.url,
+                fake_ms.sesskey,
+                42,
+                force=True,
+            ),
+        ]
+    )
+
+
+def test_delete_course_force_skips_confirmation():
+    """--force deletes directly, without any confirmation prompt."""
+    fake_ms = _fake_moodle_session()
+    with (
+        patch("py_moodle.cli.courses.MoodleSession.get", return_value=fake_ms),
+        patch("py_moodle.cli.courses.delete_course") as mock_delete,
+    ):
+        mock_delete.return_value = None
+
+        result = runner.invoke(app, ["courses", "delete", "42", "--force"])
+
+    assert result.exit_code == 0
+    assert "Course 42 deleted successfully." in result.output
+    mock_delete.assert_called_once_with(
+        fake_ms.session, fake_ms.settings.url, fake_ms.sesskey, 42, force=True
+    )

--- a/tests/unit/test_course_delete_confirmation.py
+++ b/tests/unit/test_course_delete_confirmation.py
@@ -1,0 +1,94 @@
+"""Unit tests for the ``ConfirmationRequired`` behavior of ``delete_course()``."""
+
+import pytest
+
+from py_moodle.course import ConfirmationRequired, MoodleCourseError, delete_course
+
+CONFIRM_PAGE_HTML = (
+    "<title>Test Course</title>"
+    '<form method="post" action="delete.php">'
+    '<input type="hidden" name="sesskey" value="abc123">'
+    '<input type="hidden" name="delete" value="delete-token-xyz">'
+    "</form>"
+)
+
+
+class FakeResponse:
+    """Minimal HTTP response stub for ``delete_course`` tests."""
+
+    def __init__(self, *, text="", status_code=200):
+        """Store the canned text and status code."""
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        """Mirror the requests.Response API for successful responses."""
+        return None
+
+
+class FakeSession:
+    """Fake ``requests.Session`` that records POST calls for assertions."""
+
+    def __init__(self, get_text=CONFIRM_PAGE_HTML, post_response=None):
+        """Configure the canned GET text and POST response."""
+        self.get_text = get_text
+        self.post_response = post_response or FakeResponse(text="<html>ok</html>")
+        self.post_calls = []
+
+    def get(self, url, **kwargs):
+        """Return the canned confirmation-page response."""
+        return FakeResponse(text=self.get_text)
+
+    def post(self, url, **kwargs):
+        """Record the POST call and return the canned response."""
+        self.post_calls.append((url, kwargs))
+        return self.post_response
+
+
+def test_delete_course_without_force_raises_confirmation_required(monkeypatch, capsys):
+    """delete_course(force=False) must raise instead of blocking on input()."""
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("input() must not be called")
+
+    monkeypatch.setattr("builtins.input", _fail_if_called)
+
+    session = FakeSession()
+
+    with pytest.raises(ConfirmationRequired) as excinfo:
+        delete_course(
+            session, "https://moodle.example.test", "sesskey123", 42, force=False
+        )
+
+    assert excinfo.value.course_id == 42
+    assert excinfo.value.course_title == "Test Course"
+    assert session.post_calls == []
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_delete_course_with_force_proceeds_without_raising(monkeypatch):
+    """delete_course(force=True) should submit the deletion form directly."""
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("input() must not be called")
+
+    monkeypatch.setattr("builtins.input", _fail_if_called)
+
+    session = FakeSession()
+
+    delete_course(session, "https://moodle.example.test", "sesskey123", 42, force=True)
+
+    assert len(session.post_calls) == 1
+    url, kwargs = session.post_calls[0]
+    assert url == "https://moodle.example.test/course/delete.php"
+    assert kwargs["data"]["id"] == "42"
+    assert kwargs["data"]["delete"] == "delete-token-xyz"
+    assert kwargs["data"]["confirm"] == "1"
+
+
+def test_confirmation_required_is_a_moodle_course_error():
+    """The new exception should subclass MoodleCourseError for compatibility."""
+    assert issubclass(ConfirmationRequired, MoodleCourseError)

--- a/tests/unit/test_draftfile_logging.py
+++ b/tests/unit/test_draftfile_logging.py
@@ -1,0 +1,77 @@
+"""Unit tests for the logging-based repo-id fallback warning in draftfile.py."""
+
+import logging
+
+from py_moodle.draftfile import MoodleDraftFileError, upload_file_to_draft_area
+
+
+class FakeResponse:
+    """Minimal HTTP response stub for the draft-upload endpoint."""
+
+    def __init__(self, *, json_data=None, status_code=200):
+        """Store the canned JSON payload and status code."""
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def raise_for_status(self):
+        """Mirror the requests.Response API for successful responses."""
+        return None
+
+    def json(self):
+        """Return the configured JSON payload."""
+        return self._json_data
+
+
+class FakeSession:
+    """Fake ``requests.Session`` that records POST calls for assertions."""
+
+    def __init__(self):
+        """Initialize the call log."""
+        self.post_calls = []
+
+    def post(self, url, **kwargs):
+        """Record the POST call and return a canned success response."""
+        self.post_calls.append((url, kwargs))
+        return FakeResponse(json_data={"id": 123, "filename": "test.txt"})
+
+
+def test_repo_id_fallback_logs_warning_not_print(monkeypatch, tmp_path, caplog, capsys):
+    """When repo-id auto-detection fails, a warning is logged, not printed."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello")
+
+    def _raise(*args, **kwargs):
+        raise MoodleDraftFileError("boom")
+
+    monkeypatch.setattr("py_moodle.draftfile.detect_upload_repo", _raise)
+
+    session = FakeSession()
+
+    with caplog.at_level(logging.WARNING, logger="py_moodle.draftfile"):
+        upload_file_to_draft_area(
+            session=session,
+            base_url="https://moodle.example.test",
+            sesskey="sesskey123",
+            course_id=1,
+            course_context_id=2,
+            file_path=str(test_file),
+            itemid=999,
+        )
+
+    warning_records = [
+        record
+        for record in caplog.records
+        if record.name == "py_moodle.draftfile" and record.levelno == logging.WARNING
+    ]
+    assert warning_records, "Expected a WARNING record on py_moodle.draftfile"
+    assert any(
+        "Falling back to default ID 5" in record.message for record in warning_records
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # The fallback repo_id of 5 must still be used in the outgoing payload.
+    _, kwargs = session.post_calls[0]
+    assert kwargs["data"]["repo_id"] == "5"


### PR DESCRIPTION
## Summary
Three places in `src/py_moodle/` performed direct terminal I/O instead of returning data or raising exceptions, breaking the CLI/library layering documented in `AGENTS.md`. `delete_course()` blocked on `input()` and printed `"Aborted."`; `draftfile.py` printed a warning on repo-id auto-detection failure; and `auth.py` had ~20 `print(f"[DEBUG] ...")` calls. This PR moves the confirmation decision into a typed exception (`ConfirmationRequired`) handled by the CLI, and converts the `draftfile.py`/`auth.py` prints to standard `logging` calls, while preserving all existing CLI-facing behavior (and fixing a latent bug along the way).

## Linked issue
Closes #41

## Specification
- `delete_course(force=False)` raises `ConfirmationRequired(course_id, course_title)` before any deletion POST, performing zero stdin/stdout I/O. `force=True` is unchanged.
- `courses delete` CLI command catches `ConfirmationRequired`, prompts interactively via `typer.confirm()` (preserving the `[y/N]`-style UX), and only re-invokes `delete_course(..., force=True)` on an affirmative answer. Declining prints `"Aborted."` and exits `0` without a success message (previously it printed `"Aborted."` from the library **and still** unconditionally printed `"... deleted successfully."` from the CLI — that bug is fixed).
- `draftfile.py`'s repo-id auto-detection fallback now emits a `WARNING` via `logging.getLogger("py_moodle.draftfile")` instead of `print()`; the `repo_id = 5` fallback behavior is unchanged.
- `auth.py` has zero remaining `print()` calls; all former `[DEBUG]` output goes through `logging.getLogger("py_moodle.auth")`, still gated by the existing `debug` flag/parameter and still redacting secrets (e.g. the CAS payload's `***REDACTED***` password).

## Implementation details
- `src/py_moodle/course.py`: added `ConfirmationRequired(MoodleCourseError)` exception carrying `course_id`/`course_title`; `delete_course()` now raises it when `force=False` instead of calling `input()`/`print()`; updated the `Raises:` docstring section; added `ConfirmationRequired` to `__all__`.
- `src/py_moodle/cli/courses.py`: `delete_a_course` now imports and catches `ConfirmationRequired` before the generic exception handler, reproducing the interactive confirm/decline UX with `typer.confirm()`, and only calls `delete_course(..., force=True)` after an affirmative answer.
- `src/py_moodle/draftfile.py`: added a module-level `logger = logging.getLogger("py_moodle.draftfile")`; the repo-id-detection-failure `print()` is now `logger.warning()` with the same message content.
- `src/py_moodle/auth.py`: added `import logging` and a module-level `logger = logging.getLogger("py_moodle.auth")`; every `print(f"[DEBUG] ...")` call (in `login()`, `_standard_login()`, `_cas_login()`, `_get_webservice_token()`, and `enable_webservice()`) is now `logger.debug(...)`/`logger.debug(...)`, still gated by the same `if self.debug:` / `debug` parameter checks; removed a stray commented-out `# print(resp.text)` leftover; existing secret redaction (`redacted_payload` with `***REDACTED***` password) is untouched.

## Test plan
- [x] Added failing tests first.
- [x] Confirmed the tests failed before implementation.
- [x] Implemented the feature/refactor.
- [x] Confirmed the focused tests pass.
- [x] Confirmed the full "pytest tests/unit" suite passes.

Commands run:
```bash
# Red: confirm new tests fail against the unmodified code
.venv/bin/pytest tests/unit/test_course_delete_confirmation.py tests/unit/test_cli_courses_delete.py -q
.venv/bin/pytest tests/unit/test_draftfile_logging.py tests/unit/test_auth_logging.py -q

# Green: after implementation
.venv/bin/pytest tests/unit/test_course_delete_confirmation.py tests/unit/test_cli_courses_delete.py tests/unit/test_draftfile_logging.py tests/unit/test_auth_logging.py -q

# Full fast suite (no network/Docker)
.venv/bin/pytest tests/unit -q

# Lint
.venv/bin/black --check src tests
.venv/bin/isort --check-only src tests
.venv/bin/flake8

# Regenerated CLI docs to confirm no change was needed
PYTHONPATH=src .venv/bin/python -m typer py_moodle.cli.app utils docs --output docs/cli.md --name py-moodle
```
All new tests failed before the implementation (`ImportError: cannot import name 'ConfirmationRequired'` for the course/CLI tests; `AssertionError` on empty `capsys` output for the auth/draftfile logging tests), and all 48 tests in `tests/unit` pass afterward.

## Backward compatibility
- **Breaking change for direct library callers** of `delete_course()`: calling it with `force` left at its default `False` no longer blocks on an interactive `input()` prompt — it now raises `ConfirmationRequired` immediately. Callers must either pass `force=True` or catch `ConfirmationRequired` and implement their own confirmation UX. This is documented in the `Raises:` section of `delete_course()`'s docstring. The repository has no `CHANGELOG.md` file to add a "Breaking Changes" entry to; this PR description serves as the record for the next release notes.
- `docs/recipes.md` and `docs/getting-started/` were checked and contain no example calling `delete_course()` directly as a library function, so no updates were needed there.
- **CLI end users** (`py-moodle courses delete <id>`) see no functional change other than the fixed decline-then-reports-success inconsistency: the interactive `[y/N]`-style prompt, `--force` to skip it, and overall command semantics are unchanged.
- `draftfile.py` and `auth.py` changes are fully backward compatible: no public function signature changes, no behavior changes other than the I/O channel (print → logging).

## Documentation
- Updated the `delete_course()` docstring's `Raises:` section to document `ConfirmationRequired` (flows automatically into `docs/api/course.md` via mkdocstrings).
- Added a Google-style docstring for the new `ConfirmationRequired` exception class (flows into `docs/api/course.md`).
- Checked `docs/recipes.md` and `docs/getting-started/` — no examples call `delete_course()` directly, so no changes were needed there.
- Regenerated `docs/cli.md` and confirmed it is byte-identical to the existing committed version (the `courses delete` command's `--help` text and options are unchanged; only its internal implementation changed).
- `docs/development.md`'s `DEBUG=true` example environment variable is unrelated to `auth.py`'s `debug` parameter (it is not read anywhere in the codebase), so no update was needed there.

## Risk assessment
- The main risk is the intentional breaking change to `delete_course()`'s default behavior for direct library callers relying on the old blocking `input()`. Mitigated by: keeping `MoodleCourseError` as the exception's base class (so existing broad `except MoodleCourseError` handlers still catch it), a clear docstring `Raises:` entry, and PR description callouts.
- Risk that CLI behavior subtly changes: mitigated by three dedicated CLI tests (decline, accept, `--force`) using `CliRunner` with simulated stdin, verifying exact call counts/arguments to `delete_course` and the exact output strings ("Aborted.", "deleted successfully").
- Risk that secret redaction regresses when moving `auth.py` to `logging`: mitigated by a dedicated test asserting the plaintext password is absent from `caplog.text` while the `***REDACTED***` marker is present.

## Manual verification
```python
from unittest.mock import MagicMock
from py_moodle.course import ConfirmationRequired, delete_course

session = MagicMock()
session.get.return_value = MagicMock(
    status_code=200,
    text='<title>My Course</title><input name="sesskey" value="s"><input name="delete" value="d">',
)

try:
    delete_course(session, "https://moodle.example.test", "sesskey", 42, force=False)
except ConfirmationRequired as e:
    print(e.course_id, e.course_title)
    # -> 42 My Course
```

```bash
$ py-moodle courses delete 42
Are you sure you want to delete course 'My Course' (ID 42)? [y/N]: n
Aborted.
$ echo $?
0
```

```python
import logging
logging.basicConfig(level=logging.DEBUG)
from py_moodle.auth import MoodleAuth
# auth = MoodleAuth(..., debug=True); auth.login()
# -> DEBUG:py_moodle.auth:Login: base_url=... username=... use_cas=... cas_url=...
```

## Notes for reviewers
- The CLI's `delete_course(ms.session, ..., force=True)` call inside the `except ConfirmationRequired` handler is not wrapped in its own nested `try`, matching the issue's proposed solution verbatim — if that second call raises `MoodleCourseError`, it will propagate uncaught rather than being handled by the sibling `except MoodleCourseError`/`except Exception` clauses (since those are siblings of the outer `try`, not of the inner handler). This mirrors the exact shape requested in the issue spec.
- Kept the `debug: bool` gate on both `MoodleAuth` and `enable_webservice()` around the new `logger.debug(...)` calls, per the issue's explicit recommendation, rather than removing it in favor of relying purely on the logger's configured level — a follow-up issue can revisit this.
- Removed one stray commented-out `# print(resp.text)` line in `enable_webservice()` since it was dead code directly tied to the print-removal cleanup; no other unrelated code was touched.
- Out of scope (per the issue): no new `--verbose`/`--debug` CLI flags, no changes to `MoodleCourseError`'s hierarchy beyond adding `ConfirmationRequired`, and no changes to `delete_course()`'s HTML-scraping/transport logic.
- Integration tests (`tests/test_course.py`, `tests/test_draftfile.py`) were checked; they already call `delete_course(..., force=True)` exclusively and do not assert on the old `input()`/`print()` behavior, so no updates were needed there (not runnable in this environment to confirm, per instructions).