### PR TITLE
Fix SECURITY.md to stop recommending public issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,14 +11,22 @@ Only the latest version of the plugin is supported with security updates. `pytho
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in the plugin, please report it privately and responsibly.
+If you discover a security vulnerability, please report it privately and responsibly using one of the channels below. **Do not** report vulnerabilities via public GitHub issues, GitHub Discussions, or social media.
 
-- **Preferred method:** Open an issue marked as `security` and do not include sensitive details.
-- **Alternative:** Email the maintainer directly at `info@ernesto.es`.
+- **Preferred method:** Use GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) — go to this repository's **Security** tab and select **"Report a vulnerability"**. This creates a private GitHub Security Advisory that is visible only to maintainers and the reporter until a fix is coordinated.
+- **Alternative:** If the option above is unavailable to you (for example, you do not have a GitHub account, or the feature is not yet enabled on this repository), email the maintainer directly at `info@ernesto.es`.
 
-Once reported:
-- You'll receive an acknowledgment within 3 working days.
-- We'll investigate and aim to patch confirmed vulnerabilities within 10 working days.
-- If the issue is critical and affects users broadly, we may issue a security advisory and notify on the GitHub releases page.
+### What to include
 
-Do not report security issues via public channels (e.g., Twitter, public issues, discussions).
+- Affected version, tag, or commit hash
+- Environment details (OS, Python version, Moodle version if relevant)
+- Steps to reproduce the issue
+- Impact and potential severity
+
+### What happens next
+
+- We aim to acknowledge your report within 3 working days.
+- We aim to investigate and patch confirmed vulnerabilities within 10 working days.
+- If the issue is critical and affects users broadly, we may issue a GitHub Security Advisory and notify via the GitHub releases page once a fix is available.
+
+> **Note:** The maintainer may enable GitHub's repository-level "Private vulnerability reporting" setting so the Security tab's native reporting form is available directly. This is a manual repository setting and not something this document can enable on its own.


### PR DESCRIPTION
## Summary
`SECURITY.md` previously listed opening a public GitHub issue marked `security` as the *preferred* way to report a vulnerability, which contradicted its own instruction to report "privately and responsibly" and could expose an unpatched vulnerability publicly. This PR rewrites the "Reporting a Vulnerability" section to make GitHub's Private Vulnerability Reporting the preferred channel, keeps email as the fallback, removes the public-issue instruction entirely, and adds a "what to include" checklist.

## Linked issue
Closes #46

## Specification
Documentation-only change to `SECURITY.md`:
- Preferred/primary channel: GitHub's Private Vulnerability Reporting (Security tab -> "Report a vulnerability"), private by design.
- Fallback channel: email `info@ernesto.es`, kept as documented alternative.
- Removed entirely: the "open an issue marked as `security`" instruction.
- Added: an explicit standalone reminder not to use public issues, GitHub Discussions, or social media to report vulnerabilities.
- Added: a short "what to include in a report" checklist (affected version/commit, environment, reproduction steps, impact/severity).
- Kept: the "Supported Versions" table unchanged, and the response-time expectations, reworded as targets ("we aim to...") rather than firm SLAs, with the same 3/10 working-day numbers.
- Added as a non-binding note: the maintainer may enable GitHub's repository-level "Private vulnerability reporting" setting as a follow-up (out of scope for this PR).

## Implementation details
- `SECURITY.md`: Rewrote the "Reporting a Vulnerability" section per the specification above. No other files were changed.

## Test plan
- [x] N/A — documentation-only change, no executable code path (per issue's own TDD Plan, which states no automated tests are required or applicable).
- [x] Confirmed the file is valid, well-formed Markdown by rendering it locally with Python's `markdown` library (tables + headings + lists rendered without error).
- [x] Confirmed via `grep` that no "open an issue" / public-issue instruction remains in the file.
- [x] Confirmed the full "pytest tests/unit" suite still passes (no code touched).

Commands run:
```bash
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/python -c "
import markdown
with open('SECURITY.md') as f:
    content = f.read()
html = markdown.markdown(content, extensions=['tables'])
print('Rendered OK, length:', len(html))
"
grep -n -i "open an issue" SECURITY.md   # no matches
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit -q
```

## Backward compatibility
No backward-compatibility concerns: this changes only reporting *instructions* in a Markdown file, not any code, API, CLI behavior, or configuration schema. No code, tests, or workflows were modified. Any vulnerability report already in flight via email remains valid and unaffected.

## Documentation
Updated `SECURITY.md` only. `SECURITY.md` is not referenced from `mkdocs.yml` or the docs site navigation, so no MkDocs nav or cross-link updates were needed.

## Risk assessment
Minimal risk: this is a documentation-only change with no code, dependency, or workflow impact. The only risk is a reporter following stale cached instructions from before this change, which is unavoidable and not something this PR can mitigate further.

## Manual verification
Rendered `SECURITY.md` locally with Python's `markdown` library to confirm headings, the supported-versions table, and bullet lists all render without errors. The file was also visually reviewed to confirm the preferred/fallback channel ordering, the explicit "do not use public channels" line, and the "what to include" checklist all read clearly and match the issue's SDD specification.

## Notes for reviewers
- Per the issue's explicit "Out of Scope" section, this PR does **not** enable GitHub's repository-level "Private vulnerability reporting" setting (Settings -> Security -> "Private vulnerability reporting") — that remains a manual, one-click follow-up for the repository owner, only referenced as a suggested next step in the updated doc.
- No response-time numbers were changed (still 3 working days to acknowledge, 10 working days to investigate/patch), only reworded from firm-sounding commitments to "we aim to..." targets, per the issue's explicit instruction not to introduce new SLA commitments.