### PR TITLE
Add a high-level MoodleClient public API facade

### DIFF
--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -1,0 +1,14 @@
+# MoodleClient
+
+`MoodleClient` is a high-level, discoverable facade over the function-based
+`py_moodle` modules. It owns a connected Moodle session and exposes grouped
+resource namespaces (`courses`, `sections`, `users`, `folders`, `labels`,
+`assignments`, `scorm`) instead of requiring every call site to thread
+`session`, `base_url`, `token` and `sesskey` by hand.
+
+It is a pure facade: every resource-namespace method delegates to the
+existing, already-documented functions in `course.py`, `section.py`,
+`user.py`, `folder.py`, `label.py`, `assign.py` and `scorm.py`, without
+changing their signatures or behavior.
+
+::: py_moodle.client

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,11 +71,51 @@ py-moodle courses create --fullname "Test Course" --shortname "test-001"
 py-moodle modules add label --course-id 2 --section-id 1 --name "Welcome" --intro "Welcome to the course!"
 ```
 
+## 5. Use py-moodle as a Library
+
+Besides the CLI, py-moodle can be used directly from Python scripts.
+
+The low-level modules (`course.py`, `section.py`, `folder.py`, etc.) expose
+plain functions that take `session`, `base_url`, `token` and `sesskey`
+explicitly - see [Examples](../examples.md) for that style.
+
+For scripts that call more than one or two functions, `MoodleClient` collapses
+that repetition into a single object, created once, with a discoverable
+`moodle.courses` / `moodle.sections` / `moodle.scorm` / ... API:
+
+```python
+from py_moodle import MoodleClient
+
+with MoodleClient.from_env("prod") as moodle:
+    courses = moodle.courses.list()
+    print(f"Found {len(courses)} courses")
+
+    course = moodle.courses.create(
+        fullname="Automation Demo",
+        shortname="automation-demo",
+    )
+
+    moodle.labels.add(
+        course_id=course["id"],
+        section_id=1,
+        name="Welcome",
+        html="<p>Welcome to the course.</p>",
+    )
+```
+
+`MoodleClient.from_env("prod")` reuses the same `MOODLE_PROD_*` environment
+variables configured in step 2, and the same cached, thread-safe session as
+`MoodleSession.get("prod")`. The `with` block closes the underlying HTTP
+session automatically on exit.
+
+See the [Client API Reference](../api/client.md) for the full list of
+resource namespaces.
+
 ## Next Steps
 
 - Check out the [CLI Reference](../cli.md) for all available commands
 - Read the [Configuration](configuration.md) guide for advanced setup
-- Browse [API Reference](../api/session.md) to use py-moodle as a library
+- Browse [API Reference](../api/client.md) to use py-moodle as a library
 
 !!! tip "Need Help?"
     Use `py-moodle --help` or `py-moodle COMMAND --help` for detailed command information.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -68,6 +68,28 @@ py-moodle modules add label \
 Replace the example course ID with the ID returned by the create command in
 your environment.
 
+### Equivalent recipe using `MoodleClient`
+
+The same workflow, scripted with the [`MoodleClient`](api/client.md) facade
+instead of the CLI:
+
+```python
+from py_moodle import MoodleClient
+
+with MoodleClient.from_env("prod") as moodle:
+    course = moodle.courses.create(
+        fullname="Automation Demo",
+        shortname="automation-demo",
+    )
+    section = moodle.sections.create(course["id"])
+    moodle.labels.add(
+        course_id=course["id"],
+        section_id=section.get("section", 1),
+        name="Welcome",
+        html="<p>Welcome to the course.</p>",
+    )
+```
+
 ## Upload materials into a folder
 
 Use the dedicated folder commands when you want to manage a reusable course

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - CLI Reference: cli.md
   - API Reference:
     - Core:
+      - Client: api/client.md
       - Session: api/session.md
       - Settings: api/settings.md
       - Auth: api/auth.md

--- a/src/py_moodle/__init__.py
+++ b/src/py_moodle/__init__.py
@@ -11,7 +11,14 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0"
 
+from .client import MoodleClient
 from .session import MoodleSession, MoodleSessionError
 from .settings import Settings, load_settings
 
-__all__ = ["Settings", "load_settings", "MoodleSession", "MoodleSessionError"]
+__all__ = [
+    "Settings",
+    "load_settings",
+    "MoodleSession",
+    "MoodleSessionError",
+    "MoodleClient",
+]

--- a/src/py_moodle/client.py
+++ b/src/py_moodle/client.py
@@ -1,0 +1,429 @@
+"""High-level, object-oriented facade over the ``py_moodle`` function API.
+
+``MoodleClient`` wraps a ``requests.Session``, ``base_url``, ``token`` and
+``sesskey`` tuple (obtained either explicitly or via :class:`MoodleSession`)
+and exposes grouped resource namespaces (``courses``, ``sections``, ``users``,
+``folders``, ``labels``, ``assignments``, ``scorm``) whose methods delegate to
+the existing, already-tested functions in ``course.py``, ``section.py``,
+``user.py``, ``folder.py``, ``label.py``, ``assign.py`` and ``scorm.py``.
+
+This module is purely additive: it does not modify the signature or behavior
+of any function it delegates to.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import requests
+
+from . import assign, course, folder, label, scorm, section, user
+from .session import MoodleSession
+from .settings import Settings
+
+
+class _ExplicitConnection:
+    """Holds an explicitly provided session/base_url/token/sesskey tuple."""
+
+    def __init__(
+        self,
+        session: requests.Session,
+        base_url: str,
+        token: Optional[str],
+        sesskey: Optional[str],
+    ) -> None:
+        """Store the explicit connection values as-is.
+
+        Args:
+            session: Authenticated requests session.
+            base_url: Base URL of the Moodle instance.
+            token: Webservice token, if available.
+            sesskey: Session key, if available.
+        """
+        self.session = session
+        self.base_url = base_url
+        self.token = token
+        self.sesskey = sesskey
+
+
+class _BaseResource:
+    """Base class for resource-namespace proxies bound to a client."""
+
+    def __init__(self, client: "MoodleClient") -> None:
+        """Bind the resource proxy to its owning client.
+
+        Args:
+            client: The :class:`MoodleClient` instance owning this resource.
+        """
+        self._client = client
+
+    @property
+    def _session(self) -> requests.Session:
+        """Return the client's current authenticated session."""
+        return self._client.session
+
+    @property
+    def _base_url(self) -> str:
+        """Return the client's Moodle base URL."""
+        return self._client.base_url
+
+    @property
+    def _token(self) -> Optional[str]:
+        """Return the client's webservice token, if any."""
+        return self._client.token
+
+    @property
+    def _sesskey(self) -> Optional[str]:
+        """Return the client's session key, if any."""
+        return self._client.sesskey
+
+
+class CoursesResource(_BaseResource):
+    """Course-related operations, bound to a :class:`MoodleClient`."""
+
+    def list(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.list_courses`."""
+        return course.list_courses(
+            self._session,
+            self._base_url,
+            *args,
+            token=self._token,
+            sesskey=self._sesskey,
+            **kwargs,
+        )
+
+    def create(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.create_course`."""
+        return course.create_course(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.get_course`."""
+        return course.get_course(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def delete(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.delete_course`."""
+        return course.delete_course(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def get_with_sections_and_modules(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.get_course_with_sections_and_modules`."""
+        return course.get_course_with_sections_and_modules(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def context_id(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.course.get_course_context_id`."""
+        return course.get_course_context_id(
+            self._session, self._base_url, *args, **kwargs
+        )
+
+
+class SectionsResource(_BaseResource):
+    """Section-related operations, bound to a :class:`MoodleClient`."""
+
+    def list(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.section.list_sections`."""
+        return section.list_sections(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def create(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.section.create_section`."""
+        return section.create_section(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def delete(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.section.delete_section`."""
+        return section.delete_section(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+
+class UsersResource(_BaseResource):
+    """User-related operations, bound to a :class:`MoodleClient`."""
+
+    def list(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.user.list_course_users`."""
+        return user.list_course_users(
+            self._session, self._base_url, self._token, *args, **kwargs
+        )
+
+    def create(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.user.create_user`."""
+        kwargs.setdefault("sesskey", self._sesskey)
+        return user.create_user(
+            self._session, self._base_url, self._token, *args, **kwargs
+        )
+
+    def delete(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.user.delete_user`."""
+        kwargs.setdefault("sesskey", self._sesskey)
+        return user.delete_user(
+            self._session, self._base_url, self._token, *args, **kwargs
+        )
+
+
+class FoldersResource(_BaseResource):
+    """Folder-module operations, bound to a :class:`MoodleClient`."""
+
+    def add(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.add_folder`."""
+        return folder.add_folder(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def delete(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.delete_folder`."""
+        return folder.delete_folder(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def add_file(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.add_file_to_folder`."""
+        return folder.add_file_to_folder(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def delete_file(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.delete_file_from_folder`."""
+        return folder.delete_file_from_folder(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def rename_file(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.rename_file_in_folder`."""
+        return folder.rename_file_in_folder(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def list_content(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.folder.list_folder_content`."""
+        return folder.list_folder_content(
+            self._session, self._base_url, *args, **kwargs
+        )
+
+
+class LabelsResource(_BaseResource):
+    """Label-module operations, bound to a :class:`MoodleClient`."""
+
+    def add(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.label.add_label`."""
+        return label.add_label(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def delete(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.label.delete_label`."""
+        return label.delete_label(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def update(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.label.update_label`."""
+        return label.update_label(self._session, self._base_url, *args, **kwargs)
+
+
+class AssignmentsResource(_BaseResource):
+    """Assignment-module operations, bound to a :class:`MoodleClient`."""
+
+    def add(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.assign.add_assign`."""
+        return assign.add_assign(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+
+class ScormResource(_BaseResource):
+    """SCORM-module operations, bound to a :class:`MoodleClient`."""
+
+    def add(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.scorm.add_scorm`."""
+        return scorm.add_scorm(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+    def add_ajax(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to :func:`py_moodle.scorm.add_scorm_ajax`."""
+        return scorm.add_scorm_ajax(
+            self._session, self._base_url, self._sesskey, *args, **kwargs
+        )
+
+
+class MoodleClient:
+    """High-level, discoverable facade over the ``py_moodle`` function API.
+
+    A ``MoodleClient`` owns a connected Moodle session and exposes grouped
+    resource namespaces (``courses``, ``sections``, ``users``, ``folders``,
+    ``labels``, ``assignments``, ``scorm``) instead of requiring callers to
+    thread ``session``/``base_url``/``token``/``sesskey`` through every call.
+
+    It can be built two ways:
+
+    * From explicit settings: ``MoodleClient(settings)``, which lazily wraps
+      a :class:`MoodleSession` (no network I/O happens until the session,
+      token or sesskey is actually accessed).
+    * From an explicit connection: ``MoodleClient(session=..., base_url=...,
+      token=..., sesskey=...)``, for callers who already have these values.
+    * From environment/profile: :meth:`MoodleClient.from_env`, which reuses
+      :func:`py_moodle.settings.load_settings` and the cached,
+      thread-safe :meth:`MoodleSession.get`.
+
+    It also supports the context manager protocol, closing the underlying
+    ``requests.Session`` on exit (if one was actually opened).
+    """
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        *,
+        session: Optional[requests.Session] = None,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        sesskey: Optional[str] = None,
+    ) -> None:
+        """Construct a client from explicit settings or an explicit connection.
+
+        Args:
+            settings: Environment settings used to lazily create a
+                :class:`MoodleSession`. Mutually exclusive with the explicit
+                ``session``/``base_url`` arguments.
+            session: An already-authenticated ``requests.Session``. Requires
+                ``base_url`` to also be provided.
+            base_url: Base URL of the Moodle instance (used with ``session``).
+            token: Webservice token (used with ``session``).
+            sesskey: Session key (used with ``session``).
+
+        Raises:
+            ValueError: If neither ``settings`` nor a ``session``/``base_url``
+                pair is provided.
+        """
+        self._moodle_session: Optional[MoodleSession] = None
+        self._explicit: Optional[_ExplicitConnection] = None
+
+        if settings is not None:
+            self._moodle_session = MoodleSession(settings)
+        elif session is not None and base_url is not None:
+            self._explicit = _ExplicitConnection(session, base_url, token, sesskey)
+        else:
+            raise ValueError(
+                "MoodleClient requires either a `settings` object or an "
+                "explicit `session` and `base_url` pair."
+            )
+
+        self._bind_resources()
+
+    def _bind_resources(self) -> None:
+        """Create the resource-namespace proxies bound to this client."""
+        self.courses = CoursesResource(self)
+        self.sections = SectionsResource(self)
+        self.users = UsersResource(self)
+        self.folders = FoldersResource(self)
+        self.labels = LabelsResource(self)
+        self.assignments = AssignmentsResource(self)
+        self.scorm = ScormResource(self)
+
+    @classmethod
+    def from_env(cls, env: Optional[str] = None) -> "MoodleClient":
+        """Build a client from environment/profile configuration.
+
+        Internally calls :meth:`MoodleSession.get` (which itself calls
+        :func:`py_moodle.settings.load_settings`), reusing its existing
+        per-environment caching, thread-safety, and lazy-login behavior.
+
+        Args:
+            env: Environment key (e.g. ``"local"``, ``"staging"``, ``"prod"``).
+                Defaults to ``MoodleSession.get``'s own default (``"local"``).
+
+        Returns:
+            MoodleClient: A client wired to the cached session for ``env``.
+        """
+        instance = cls.__new__(cls)
+        instance._moodle_session = MoodleSession.get(env)
+        instance._explicit = None
+        instance._bind_resources()
+        return instance
+
+    # ------------- connection properties -------------
+
+    @property
+    def base_url(self) -> str:
+        """Return the Moodle instance's base URL."""
+        if self._moodle_session is not None:
+            return self._moodle_session.settings.url
+        assert self._explicit is not None
+        return self._explicit.base_url
+
+    @property
+    def session(self) -> requests.Session:
+        """Return the authenticated ``requests.Session`` (login once)."""
+        if self._moodle_session is not None:
+            return self._moodle_session.session
+        assert self._explicit is not None
+        return self._explicit.session
+
+    @property
+    def token(self) -> Optional[str]:
+        """Return the webservice token, or ``None`` if not available."""
+        if self._moodle_session is not None:
+            return self._moodle_session.token
+        assert self._explicit is not None
+        return self._explicit.token
+
+    @property
+    def sesskey(self) -> Optional[str]:
+        """Return the session key, or ``None`` if not available."""
+        if self._moodle_session is not None:
+            return self._moodle_session.sesskey
+        assert self._explicit is not None
+        return self._explicit.sesskey
+
+    # ------------- context manager -------------
+
+    def __enter__(self) -> "MoodleClient":
+        """Return this client, enabling ``with MoodleClient(...) as moodle``."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Close the underlying session on exit; never raises."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying ``requests.Session``, if one was opened.
+
+        Safe to call multiple times, and safe to call even if no HTTP session
+        was ever established (it will not force a login just to close it).
+        """
+        opened_session = self._peek_opened_session()
+        if opened_session is not None:
+            try:
+                opened_session.close()
+            except Exception:
+                pass
+
+    def _peek_opened_session(self) -> Optional[requests.Session]:
+        """Return the underlying session only if it already exists.
+
+        Unlike the ``session`` property, this never triggers a lazy login.
+        """
+        if self._moodle_session is not None:
+            return getattr(self._moodle_session, "_session", None)
+        assert self._explicit is not None
+        return self._explicit.session
+
+
+__all__ = [
+    "MoodleClient",
+    "CoursesResource",
+    "SectionsResource",
+    "UsersResource",
+    "FoldersResource",
+    "LabelsResource",
+    "AssignmentsResource",
+    "ScormResource",
+]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,351 @@
+"""Unit tests for the ``MoodleClient`` high-level facade."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import py_moodle
+from py_moodle.session import MoodleSession
+from py_moodle.settings import Settings
+
+
+class StubResponse:
+    """Minimal HTTP response object used by :class:`StubSession`."""
+
+    def __init__(self, *, text="", json_data=None, status_code=200):
+        self.text = text
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        """Return the configured JSON payload."""
+        return self.json_data
+
+    def raise_for_status(self):
+        """Mirror the requests.Response API for successful responses."""
+        return None
+
+
+class StubSession:
+    """Minimal stand-in for ``requests.Session`` used in login stubs."""
+
+    def __init__(self, *, sesskey="sesskey-abc", webservice_token="token-abc"):
+        self.sesskey = sesskey
+        self.webservice_token = webservice_token
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        """Return a canned GET response."""
+        return StubResponse(text="<html></html>")
+
+    def post(self, url, **kwargs):
+        """Return a canned POST response."""
+        return StubResponse(json_data={})
+
+    def close(self):
+        """Record that the session was closed."""
+        self.closed = True
+
+
+def build_settings(env_name="local"):
+    """Build minimal Settings for client construction tests."""
+    return Settings(
+        env_name=env_name,
+        url="https://moodle.example.test",
+        username="user",
+        password="secret",
+        use_cas=False,
+        cas_url=None,
+        webservice_token=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_moodle_session_cache():
+    """Ensure MoodleSession's per-environment cache does not leak between tests."""
+    MoodleSession._cache.clear()
+    yield
+    MoodleSession._cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_client_construction_explicit_settings(monkeypatch):
+    """MoodleClient(settings) derives session/base_url/token/sesskey lazily."""
+    from py_moodle.client import MoodleClient
+
+    stub_session = StubSession()
+    monkeypatch.setattr("py_moodle.session.login", lambda *a, **k: stub_session)
+
+    client = MoodleClient(build_settings())
+
+    assert client.base_url == "https://moodle.example.test"
+    assert client.token == "token-abc"
+    assert client.sesskey == "sesskey-abc"
+    assert client.session is stub_session
+
+
+def test_client_construction_explicit_connection():
+    """MoodleClient(session=..., base_url=..., ...) works without Settings."""
+    from py_moodle.client import MoodleClient
+
+    stub_session = StubSession()
+
+    client = MoodleClient(
+        session=stub_session,
+        base_url="https://moodle.example.test",
+        token="token-xyz",
+        sesskey="sesskey-xyz",
+    )
+
+    assert client.session is stub_session
+    assert client.base_url == "https://moodle.example.test"
+    assert client.token == "token-xyz"
+    assert client.sesskey == "sesskey-xyz"
+
+
+def test_client_requires_settings_or_explicit_connection():
+    """Constructing with neither settings nor session/base_url must fail clearly."""
+    from py_moodle.client import MoodleClient
+
+    with pytest.raises(ValueError):
+        MoodleClient()
+
+
+def test_client_from_env(monkeypatch):
+    """from_env() loads settings for the profile and wires a cached MoodleSession."""
+    from py_moodle.client import MoodleClient
+
+    monkeypatch.setenv("MOODLE_TEST_URL", "https://moodle.example.test")
+    monkeypatch.setenv("MOODLE_TEST_USERNAME", "user")
+    monkeypatch.setenv("MOODLE_TEST_PASSWORD", "secret")
+    stub_session = StubSession()
+    monkeypatch.setattr("py_moodle.session.login", lambda *a, **k: stub_session)
+
+    client = MoodleClient.from_env("test")
+
+    assert client.base_url == "https://moodle.example.test"
+    assert client.token == "token-abc"
+    assert client.sesskey == "sesskey-abc"
+    assert client.session is stub_session
+    # Confirm it reused MoodleSession's caching for the "test" environment.
+    assert MoodleSession.get("test").session is stub_session
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+def test_client_context_manager_enter_returns_self():
+    """__enter__ returns the same client instance."""
+    from py_moodle.client import MoodleClient
+
+    client = MoodleClient(
+        session=StubSession(),
+        base_url="https://moodle.example.test",
+        token="t",
+        sesskey="s",
+    )
+
+    with client as moodle:
+        assert moodle is client
+
+
+def test_client_context_manager_exit_closes_session():
+    """__exit__ closes the underlying requests.Session exactly once, safely."""
+    from py_moodle.client import MoodleClient
+
+    stub_session = StubSession()
+    client = MoodleClient(
+        session=stub_session,
+        base_url="https://moodle.example.test",
+        token="t",
+        sesskey="s",
+    )
+
+    with client:
+        pass
+
+    assert stub_session.closed is True
+
+    # Calling __exit__ again must not raise.
+    client.__exit__(None, None, None)
+
+    # Nor must it raise when invoked after an exception inside the block.
+    with pytest.raises(RuntimeError):
+        with client:
+            raise RuntimeError("boom")
+
+
+def test_client_context_manager_exit_without_open_session_is_safe(monkeypatch):
+    """__exit__ must not raise or force a login when the session was never used."""
+    from py_moodle.client import MoodleClient
+
+    def _fail_login(*args, **kwargs):
+        raise AssertionError("close() must not trigger a lazy login")
+
+    monkeypatch.setattr("py_moodle.session.login", _fail_login)
+
+    client = MoodleClient(build_settings())
+
+    with client:
+        pass  # Never touch client.session/.token/.sesskey.
+
+
+# ---------------------------------------------------------------------------
+# Resource namespaces
+# ---------------------------------------------------------------------------
+
+
+def test_client_exposes_resource_namespaces():
+    """Each resource namespace is a distinct, non-None object bound to the client."""
+    from py_moodle.client import (
+        AssignmentsResource,
+        CoursesResource,
+        FoldersResource,
+        LabelsResource,
+        MoodleClient,
+        ScormResource,
+        SectionsResource,
+        UsersResource,
+    )
+
+    client = MoodleClient(
+        session=StubSession(),
+        base_url="https://moodle.example.test",
+        token="t",
+        sesskey="s",
+    )
+
+    expected_types = {
+        "courses": CoursesResource,
+        "sections": SectionsResource,
+        "users": UsersResource,
+        "folders": FoldersResource,
+        "labels": LabelsResource,
+        "assignments": AssignmentsResource,
+        "scorm": ScormResource,
+    }
+
+    seen_ids = set()
+    for attr_name, expected_type in expected_types.items():
+        resource = getattr(client, attr_name)
+        assert resource is not None
+        assert resource is not client
+        assert isinstance(resource, expected_type)
+        seen_ids.add(id(resource))
+
+    assert len(seen_ids) == len(expected_types)
+
+
+# ---------------------------------------------------------------------------
+# Delegation
+# ---------------------------------------------------------------------------
+
+
+def test_courses_list_delegates_to_list_courses(monkeypatch):
+    """moodle.courses.list() delegates to course.list_courses with client wiring."""
+    from py_moodle.client import MoodleClient
+
+    mock_list_courses = MagicMock(return_value=[{"id": 1}])
+    monkeypatch.setattr("py_moodle.course.list_courses", mock_list_courses)
+
+    client = MoodleClient(
+        session=StubSession(),
+        base_url="https://moodle.example.test",
+        token="tok",
+        sesskey="sess",
+    )
+
+    result = client.courses.list()
+
+    mock_list_courses.assert_called_once_with(
+        client.session, client.base_url, token="tok", sesskey="sess"
+    )
+    assert result == [{"id": 1}]
+
+
+def test_courses_create_delegates_with_kwargs(monkeypatch):
+    """moodle.courses.create(**kwargs) forwards kwargs to course.create_course."""
+    from py_moodle.client import MoodleClient
+
+    mock_create_course = MagicMock(return_value={"id": 42})
+    monkeypatch.setattr("py_moodle.course.create_course", mock_create_course)
+
+    client = MoodleClient(
+        session=StubSession(),
+        base_url="https://moodle.example.test",
+        token="tok",
+        sesskey="sess",
+    )
+
+    result = client.courses.create(
+        fullname="My course", shortname="my-course", categoryid=1
+    )
+
+    mock_create_course.assert_called_once_with(
+        client.session,
+        client.base_url,
+        "sess",
+        fullname="My course",
+        shortname="my-course",
+        categoryid=1,
+    )
+    assert result == {"id": 42}
+
+
+def test_scorm_add_delegates_to_add_scorm(monkeypatch):
+    """moodle.scorm.add(**kwargs) forwards kwargs to scorm.add_scorm."""
+    from py_moodle.client import MoodleClient
+
+    mock_add_scorm = MagicMock(return_value=99)
+    monkeypatch.setattr("py_moodle.scorm.add_scorm", mock_add_scorm)
+
+    client = MoodleClient(
+        session=StubSession(),
+        base_url="https://moodle.example.test",
+        token="tok",
+        sesskey="sess",
+    )
+
+    result = client.scorm.add(
+        course_id=1, section_id=1, name="SCORM 1", file_path="package.zip"
+    )
+
+    mock_add_scorm.assert_called_once_with(
+        client.session,
+        client.base_url,
+        "sess",
+        course_id=1,
+        section_id=1,
+        name="SCORM 1",
+        file_path="package.zip",
+    )
+    assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# Public API surface / backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports_moodle_client():
+    """Confirm MoodleClient is importable from the top-level package."""
+    from py_moodle import MoodleClient
+    from py_moodle.client import MoodleClient as ClientModuleMoodleClient
+
+    assert MoodleClient is ClientModuleMoodleClient
+    assert "MoodleClient" in py_moodle.__all__
+
+
+def test_existing_function_imports_unaffected():
+    """Direct low-level imports keep working unchanged (regression guard)."""
+    from py_moodle.course import list_courses
+
+    assert callable(list_courses)


### PR DESCRIPTION
## Summary
`py_moodle` is a collection of stateless, function-based modules where every public function requires the caller to thread `session`, `base_url`, `token`/`sesskey` through every call. This PR adds a `MoodleClient` facade that owns a connected Moodle session once and exposes grouped, discoverable resource namespaces (`courses`, `sections`, `users`, `folders`, `labels`, `assignments`, `scorm`) that delegate to the existing functions unchanged. This is a pure, additive facade: no existing function signature, return type, or exception behavior changes.

## Linked issue
Closes #37

## Specification
- `MoodleClient(settings)` (or `MoodleClient(session=..., base_url=..., token=..., sesskey=...)`) constructs a client without eager network I/O; `.session`/`.token`/`.sesskey` are derived lazily.
- `MoodleClient.from_env(env=None)` internally uses `load_settings(env)` via `MoodleSession.get(env)`, reusing its existing caching/thread-safety/lazy-login behavior.
- `MoodleClient` supports the context manager protocol: `__enter__` returns `self`; `__exit__` closes the underlying `requests.Session` if one was actually opened, never raises (even called twice, or after an exception, or when the session was never opened - it does not force a login just to close it).
- `moodle.courses`, `.sections`, `.users`, `.folders`, `.labels`, `.assignments`, `.scorm` are resource-proxy objects bound to the client's session/base_url/token/sesskey; their methods (`list`, `create`, `get`, `delete`, `add`, ...) mirror and delegate to the underlying module functions, injecting `session`/`base_url`/`token`/`sesskey` and forwarding all other args/kwargs unchanged.
- `MoodleClient` is exported from `py_moodle/__init__.py` and added to `__all__`.

## Implementation details
- `src/py_moodle/client.py` (new): `MoodleClient` class plus `CoursesResource`, `SectionsResource`, `UsersResource`, `FoldersResource`, `LabelsResource`, `AssignmentsResource`, `ScormResource` proxy classes (all subclassing a small internal `_BaseResource` that exposes `_session`/`_base_url`/`_token`/`_sesskey` properties reading from the owning client). Each resource method calls the wrapped module function via the imported module object (e.g. `course.list_courses(...)`) so `unittest.mock.patch("py_moodle.course.list_courses", ...)` correctly intercepts calls made through the client. `MoodleClient.close()`/`__exit__` peek at the private `MoodleSession._session` attribute (an existing pattern already used in `tests/unit/test_error_messages.py`) to avoid forcing a lazy login just to close a session that was never opened.
- `src/py_moodle/__init__.py`: import and export `MoodleClient` in `__all__`, alongside the existing `Settings`, `load_settings`, `MoodleSession`, `MoodleSessionError` exports.
- `tests/unit/test_client.py` (new): 13 tests covering explicit-settings construction, explicit-connection construction, missing-argument validation, `from_env()`, context-manager enter/exit (including double-exit, exit-after-exception, and exit-without-ever-opening-a-session), resource-namespace presence/distinctness, delegation with kwargs passthrough (`courses.list`, `courses.create`, `scorm.add`), the public export, and a regression guard for existing direct function imports.
- `docs/api/client.md` (new): mkdocstrings page for the new module, wired into `mkdocs.yml` under "API Reference > Core".
- `docs/getting-started/quickstart.md`: new "Use py-moodle as a Library" section showing `MoodleClient.from_env("prod")` as a context manager, alongside (not replacing) the existing low-level function-based example in `docs/examples.md`.
- `docs/recipes.md`: added a `MoodleClient`-based equivalent of the existing "Create a course and add a welcome label" CLI recipe, for direct comparison.

## Test plan
- [x] Added failing tests first.
- [x] Confirmed the tests failed before implementation.
- [x] Implemented the feature/refactor.
- [x] Confirmed the focused tests pass.
- [x] Confirmed the full "pytest tests/unit" suite passes.

Commands run:
```bash
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit/test_client.py -q   # red: 12 failures (ModuleNotFoundError / ImportError)
# ... implemented src/py_moodle/client.py and __init__.py export ...
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit/test_client.py -q   # green: 13 passed
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit -q                  # green: 51 passed, no regressions
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/black --check src tests
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/isort --check-only src tests
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/flake8
```

## Backward compatibility
Purely additive:
- No existing function signature, return type, or exception behavior changes in `course.py`, `section.py`, `user.py`, `folder.py`, `label.py`, `assign.py`, or `scorm.py`.
- No existing export removed from `src/py_moodle/__init__.py`; `MoodleClient` is added alongside `Settings`, `load_settings`, `MoodleSession`, `MoodleSessionError`.
- No existing CLI command, module, or test is modified.
- `from py_moodle.course import list_courses` (and equivalents) continue to work identically; covered by a regression-guard test.

## Documentation
- Added `docs/api/client.md` (mkdocstrings-generated) and wired it into `mkdocs.yml` under "API Reference > Core".
- Added a "Use py-moodle as a Library" section to `docs/getting-started/quickstart.md` demonstrating `MoodleClient.from_env("prod")` as a context manager.
- Added a `MoodleClient`-based recipe to `docs/recipes.md`, next to the existing CLI-based recipe it mirrors.
- `docs/cli.md` intentionally not touched (no CLI changes in this PR).
- Verified `mkdocs build` (non-strict) renders the new page correctly and introduces no new warnings versus the pre-existing baseline (there is a pre-existing `cli.md` nav warning unrelated to this change, since that file is only generated on demand and isn't present in a fresh checkout).

## Risk assessment
- Low risk: `client.py` is a new, additive module; it imports and calls existing functions without altering them.
- The one internal-attribute touch (`MoodleSession._session`) is read-only and used only to avoid forcing an unwanted login during cleanup; it follows an existing precedent in `tests/unit/test_error_messages.py` that directly manipulates the same attribute. If `MoodleSession`'s internals change in the future, only this "does a session already exist" peek would need updating - `MoodleClient`'s public behavior does not otherwise depend on `MoodleSession` internals.
- `MoodleClient` resource proxies forward args/kwargs verbatim to the wrapped functions, so any errors they raise (e.g. `MoodleCourseError`, `MoodleScormError`) propagate unchanged - no new error-handling surface was introduced.

## Manual verification
```python
from unittest.mock import MagicMock
from py_moodle.client import MoodleClient

client = MoodleClient(
    session=MagicMock(),
    base_url="https://moodle.example.test",
    token="tok",
    sesskey="sess",
)

# Resource namespaces are discoverable and distinct:
assert client.courses is not client
assert client.scorm is not client.courses

with client as moodle:
    # moodle.courses.list() -> delegates to py_moodle.course.list_courses(
    #     moodle.session, moodle.base_url, token="tok", sesskey="sess")
    pass
# __exit__ closed the underlying (mocked) requests.Session exactly once.
```

Real end-to-end usage (requires a live Moodle instance, not run here):
```python
from py_moodle import MoodleClient

with MoodleClient.from_env("prod") as moodle:
    course = moodle.courses.create(fullname="Demo", shortname="demo-1")
    moodle.labels.add(course_id=course["id"], section_id=1, name="Welcome", html="<p>Hi</p>")
```

## Notes for reviewers
- Resource-proxy method names were chosen to mirror the underlying function names as closely as practical while staying short and discoverable (e.g. `courses.list()` -> `list_courses`, `courses.get_with_sections_and_modules()` -> `get_course_with_sections_and_modules`, `folders.add_file()` -> `add_file_to_folder`). All of these are internal-structure choices left to implementer discretion per the issue.
- Out of scope, per the issue, and intentionally not done here: typed domain models (e.g. a `Course` dataclass), any CLI migration to use `MoodleClient` internally, retry/backoff/error-normalization work, and any "ensure"/idempotent/dry-run operations.
- `course.py` also defines its own local `list_sections(course_contents)` helper (a pure data transform over already-fetched course contents, unrelated to `section.py`'s session-based `list_sections`); it is intentionally not exposed on `CoursesResource` since it takes no session/base_url and doesn't fit the delegation pattern - callers can still reach it directly via `py_moodle.course.list_sections` as before.