### PR TITLE
Centralize HTTP requests, timeouts, retries, and error handling

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -1,0 +1,3 @@
+# HTTP
+
+::: py_moodle.http

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,22 @@ def create_course(session: requests.Session, url: str, course_data: dict, token:
     pass
 ```
 
+### Making HTTP Requests
+
+`src/py_moodle/http.py` centralizes HTTP behavior for talking to Moodle:
+default timeouts (from `config.py`), conservative retry-with-backoff for
+safe GET-style requests only, typed exceptions (`MoodleHttpError`,
+`MoodleTimeoutError`, `MoodleWebserviceError`) instead of raw `requests`
+exceptions or `json.JSONDecodeError`, and redaction of secrets (webservice
+token, `sesskey`, password, cookies, `Authorization` header) from
+exception messages. New code that talks to Moodle should prefer the
+helpers in this module (`request_webservice`, `request_html_get`,
+`request_form_post`, `request_ajax`, `upload_file`) over calling
+`session.get`/`session.post`/`requests.post` directly. Only a few call
+sites have been migrated so far (`session.py`'s `MoodleSession.call()` and
+`course.py`'s `list_courses()`/`create_course()`); migrating the remaining
+modules is tracked as follow-up work.
+
 ## Testing
 
 ### Running Tests

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
   - API Reference:
     - Core:
       - Session: api/session.md
+      - HTTP: api/http.md
       - Settings: api/settings.md
       - Auth: api/auth.md
     - Course Management:

--- a/src/py_moodle/course.py
+++ b/src/py_moodle/course.py
@@ -14,6 +14,13 @@ from typing import Any, Dict, List
 
 import requests
 
+from .http import (
+    MoodleHttpError,
+    request_ajax,
+    request_form_post,
+    request_html_get,
+    request_webservice,
+)
 from .permissions import requires_role
 
 
@@ -91,32 +98,19 @@ def list_courses(
     if sesskey is None and hasattr(session, "sesskey"):
         sesskey = getattr(session, "sesskey", None)
 
-    # If token is present but invalid, fallback to AJAX if possible
+    # If token is present but invalid (or the call otherwise fails), fall
+    # back to the AJAX endpoint below.
     if token:
-        url = f"{base_url}/webservice/rest/server.php"
-        params = {
-            "wstoken": token,
-            "wsfunction": "core_course_get_courses",
-            "moodlewsrestformat": "json",
-        }
-        resp = session.post(url, data=params)
         try:
-            result = resp.json()
-            # If token is invalid, fallback to AJAX if possible
-            if (
-                isinstance(result, dict)
-                and "exception" in result
-                and "Invalid token" in result.get("message", "")
-            ):
-                # fallback to AJAX below, do not raise
-                pass
-            elif isinstance(result, dict) and "exception" in result:
-                raise MoodleCourseError(result.get("message", "Unknown error"))
-            else:
-                # Sort by ID ascending before returning
-                return sorted(result, key=lambda c: c.get("id", 0))
+            result = request_webservice(
+                session, base_url, "core_course_get_courses", token=token
+            )
+            # Sort by ID ascending before returning
+            return sorted(result, key=lambda c: c.get("id", 0))
         except Exception:
-            # fallback to AJAX below if possible
+            # Any webservice failure (invalid token, transient network
+            # error, unexpected payload shape, or a Moodle-reported error)
+            # falls back to the AJAX endpoint below.
             pass
 
     if not sesskey:
@@ -125,34 +119,22 @@ def list_courses(
             "Log in again, or use a user that can access the Moodle mobile "
             "web service."
         )
-    url = f"{base_url}/lib/ajax/service.php?sesskey={sesskey}"
 
     # Refresh session before AJAX call to prevent "session expired" errors.
-    session.get(f"{base_url}/my/")
+    request_html_get(session, f"{base_url}/my/")
 
-    data = [{"index": 0, "methodname": "core_course_get_courses", "args": {}}]
-    headers = {"Content-Type": "application/json"}
-    resp = session.post(url, json=data, headers=headers)
-    if resp.status_code != 200:
-        raise MoodleCourseError(f"Failed to list courses. Status: {resp.status_code}")
+    url = f"{base_url}/lib/ajax/service.php?sesskey={sesskey}"
+    payload = [{"index": 0, "methodname": "core_course_get_courses", "args": {}}]
     try:
-        result = resp.json()
-        # Defensive: check for error in AJAX response
-        if (
-            result
-            and isinstance(result, list)
-            and "error" in result[0]
-            and result[0]["error"]
-        ):
-            raise MoodleCourseError(
-                result[0].get("exception", {}).get("message", "Unknown error")
-            )
+        result = request_ajax(session, url, payload)
         # The data is in result[0]["data"]
         courses = result[0]["data"]
         # Sort by ID ascending before returning
         return sorted(courses, key=lambda c: c.get("id", 0))
+    except MoodleHttpError as e:
+        raise MoodleCourseError(f"Failed to list courses: {e}") from e
     except Exception as e:
-        raise MoodleCourseError(f"Failed to parse courses: {e}")
+        raise MoodleCourseError(f"Failed to parse courses: {e}") from e
 
 
 @requires_role("manager")
@@ -288,9 +270,17 @@ def create_course(
     # Important: send data as application/x-www-form-urlencoded, not as a plain dict
 
     encoded_payload = urllib.parse.urlencode(payload)
-    resp = session.post(
-        url_plain, data=encoded_payload, headers=headers, allow_redirects=False
-    )
+    try:
+        resp = request_form_post(
+            session,
+            url_plain,
+            data=encoded_payload,
+            headers=headers,
+            allow_redirects=False,
+            raise_for_status=False,
+        )
+    except MoodleHttpError as e:
+        raise MoodleCourseError(f"Failed to create course: {e}") from e
 
     # Moodle can respond with 303, 302, or even 200 if it doesn't redirect
     # Check if the shortname already exists (typical Moodle error)

--- a/src/py_moodle/http.py
+++ b/src/py_moodle/http.py
@@ -1,0 +1,632 @@
+"""Centralized HTTP request handling for talking to Moodle.
+
+This module is the single place responsible for:
+
+- Applying the shared timeout policy from :mod:`py_moodle.config` by
+  default, with an optional override for callers that need it.
+- Retrying safe, idempotent GET-style requests with a small, bounded
+  backoff on transient network errors (``ConnectionError``/``Timeout``),
+  while *never* retrying POST/mutating requests automatically.
+- Raising typed, normalized exceptions (:class:`MoodleHttpError`,
+  :class:`MoodleTimeoutError`, :class:`MoodleWebserviceError`) instead of
+  letting raw ``requests`` exceptions or ``json.JSONDecodeError`` escape.
+- Parsing Moodle webservice error payloads (``exception``/``errorcode``/
+  ``message``) into a typed exception with those fields accessible.
+- Redacting known secret-shaped values (webservice token, ``sesskey``,
+  password, cookies, ``Authorization`` header) from the URL, params,
+  headers, and response body text used to build any exception message, so
+  secrets never appear in ``str()``/``repr()`` of a raised exception.
+
+Only a handful of call sites are migrated onto this module so far:
+``session.py``'s ``MoodleSession.call()`` and ``course.py``'s
+``list_courses()``/``create_course()``. The remaining modules that call
+``session.get``/``session.post``/``requests.post`` directly are left
+untouched and are tracked as follow-up work; new call sites should prefer
+the helpers in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+
+from .config import (
+    DEFAULT_REQUEST_TIMEOUT,
+    DEFAULT_SCRAPE_TIMEOUT,
+    DEFAULT_UPLOAD_TIMEOUT,
+)
+
+#: Marker substituted for any redacted secret value.
+REDACTED = "***REDACTED***"
+
+#: Maximum length of a response-body snippet kept in an exception message.
+_TRUNCATE_LENGTH = 500
+
+#: Keys (case-insensitive) treated as secret-shaped wherever they appear:
+#: in query params, form/JSON data, or request headers.
+_SECRET_KEYS = {
+    "wstoken",
+    "token",
+    "sesskey",
+    "password",
+    "pass",
+    "pwd",
+    "authorization",
+    "cookie",
+    "set-cookie",
+}
+
+#: Total number of attempts made for retryable (GET-style) requests.
+_RETRY_ATTEMPTS = 3
+
+#: Base backoff delay, in seconds, multiplied by the attempt number.
+_RETRY_BACKOFF_BASE_SECONDS = 0.01
+
+
+class MoodleHttpError(Exception):
+    """Base exception for HTTP-layer failures talking to Moodle.
+
+    Attributes:
+        status_code: HTTP status code of the failing response, if any.
+        url: Redacted URL involved in the failing request, if known.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        url: Optional[str] = None,
+    ) -> None:
+        """Initialize the error from an already-redacted message.
+
+        Args:
+            message: Human-readable, already-redacted error message.
+            status_code: HTTP status code of the failing response, if any.
+            url: Redacted URL involved in the failing request, if known.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.url = url
+
+
+class MoodleTimeoutError(MoodleHttpError):
+    """Raised when a request times out or fails to connect after retries."""
+
+
+class MoodleWebserviceError(MoodleHttpError):
+    """Raised when Moodle returns a webservice-shaped error payload.
+
+    Attributes:
+        errorcode: Moodle ``errorcode`` value from the failed response.
+        moodle_exception: Moodle ``exception`` class name from the failed
+            response (e.g. ``"invalid_parameter_exception"``).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        errorcode: Optional[str] = None,
+        moodle_exception: Optional[str] = None,
+        status_code: Optional[int] = None,
+        url: Optional[str] = None,
+    ) -> None:
+        """Initialize the error with Moodle's error payload fields.
+
+        Args:
+            message: Human-readable, already-redacted error message.
+            errorcode: Moodle ``errorcode`` value from the failed response.
+            moodle_exception: Moodle ``exception`` class name from the
+                failed response.
+            status_code: HTTP status code of the failing response, if any.
+            url: Redacted URL involved in the failing request, if known.
+        """
+        super().__init__(message, status_code=status_code, url=url)
+        self.errorcode = errorcode
+        self.moodle_exception = moodle_exception
+
+
+# ---------------------------------------------------------------------------
+# Redaction helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_secret_key(key: Any) -> bool:
+    """Return whether a param/header key is treated as secret-shaped."""
+    return str(key).lower() in _SECRET_KEYS
+
+
+def _collect_secrets(
+    *,
+    url: Optional[str] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, Any]] = None,
+    data: Optional[Any] = None,
+) -> List[str]:
+    """Collect literal secret values from a URL, params, headers, and body.
+
+    Args:
+        url: Request URL, whose query string may embed secrets.
+        params: Query/form parameters that may contain secret values.
+        headers: Request headers that may contain secret values.
+        data: Form body, either a mapping or an already-urlencoded string,
+            that may contain secret values.
+
+    Returns:
+        List[str]: Literal secret values found, for text scrubbing.
+    """
+    secrets: List[str] = []
+    if url and "?" in url:
+        query = urlsplit(url).query
+        for key, value in parse_qsl(query, keep_blank_values=True):
+            if _is_secret_key(key) and value:
+                secrets.append(value)
+    for source in (params, headers):
+        if not source:
+            continue
+        for key, value in source.items():
+            if _is_secret_key(key) and value:
+                secrets.append(str(value))
+    if data:
+        if isinstance(data, Mapping):
+            for key, value in data.items():
+                if _is_secret_key(key) and value:
+                    secrets.append(str(value))
+        elif isinstance(data, str):
+            for key, value in parse_qsl(data, keep_blank_values=True):
+                if _is_secret_key(key) and value:
+                    secrets.append(value)
+    return secrets
+
+
+def _redact_url(url: Optional[str]) -> Optional[str]:
+    """Redact known secret query-string parameters embedded in a URL."""
+    if not url or "?" not in url:
+        return url
+    parsed = urlsplit(url)
+    if not parsed.query:
+        return url
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    redacted_pairs = [
+        (key, REDACTED if _is_secret_key(key) else value) for key, value in pairs
+    ]
+    return urlunsplit(parsed._replace(query=urlencode(redacted_pairs)))
+
+
+def _redact_text(text: Optional[str], secrets: List[str]) -> Optional[str]:
+    """Replace any literal secret value found in text with the marker."""
+    if not text:
+        return text
+    redacted = text
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, REDACTED)
+    return redacted
+
+
+def _truncate(text: Optional[str], length: int = _TRUNCATE_LENGTH) -> str:
+    """Truncate a response body snippet for inclusion in an error message."""
+    if not text:
+        return ""
+    if len(text) <= length:
+        return text
+    return text[:length] + "...(truncated)"
+
+
+# ---------------------------------------------------------------------------
+# Low-level request execution
+# ---------------------------------------------------------------------------
+
+
+def _send_request(
+    session: Any,
+    method: str,
+    url: str,
+    *,
+    timeout: Any,
+    retryable: bool,
+    headers: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Send a single HTTP request through ``session`` with policy applied.
+
+    Args:
+        session: A ``requests.Session``-like object (or the ``requests``
+            module itself) exposing ``get``/``post`` callables.
+        method: Either ``"get"`` or ``"post"``.
+        url: Absolute URL to request.
+        timeout: Timeout value/tuple forwarded to the underlying call.
+        retryable: Whether transient connection/timeout errors should be
+            retried with backoff. This must only ever be ``True`` for
+            safe, idempotent GET-style requests; POST/mutating requests
+            must always pass ``False`` so a non-idempotent Moodle mutation
+            is never automatically duplicated.
+        headers: Optional request headers.
+        **kwargs: Additional keyword arguments forwarded to the
+            underlying session call (e.g. ``params``, ``data``, ``json``).
+
+    Returns:
+        The response object returned by the underlying session call.
+
+    Raises:
+        MoodleTimeoutError: If the request times out, after retries are
+            exhausted for retryable requests.
+        MoodleHttpError: If a connection error occurs, after retries are
+            exhausted for retryable requests.
+    """
+    call = getattr(session, method)
+    request_kwargs: Dict[str, Any] = {"timeout": timeout, "headers": headers}
+    request_kwargs.update(kwargs)
+
+    secrets = _collect_secrets(url=url, params=kwargs.get("params"), headers=headers)
+    attempts = _RETRY_ATTEMPTS if retryable else 1
+    last_error_kind: Optional[str] = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return call(url, **request_kwargs)
+        except requests.exceptions.Timeout:
+            last_error_kind = "timeout"
+        except requests.exceptions.ConnectionError:
+            last_error_kind = "connection"
+        if attempt < attempts:
+            time.sleep(_RETRY_BACKOFF_BASE_SECONDS * attempt)
+
+    redacted_url = _redact_url(url)
+    message = _redact_text(
+        f"Request to {redacted_url} failed after {attempts} attempt(s) "
+        f"due to a {last_error_kind} error.",
+        secrets,
+    )
+    if last_error_kind == "timeout":
+        raise MoodleTimeoutError(message, url=redacted_url)
+    raise MoodleHttpError(message, url=redacted_url)
+
+
+def _raise_for_status(
+    response: Any,
+    *,
+    url: Optional[str] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, Any]] = None,
+    data: Optional[Any] = None,
+) -> None:
+    """Raise ``MoodleHttpError`` for a 4xx/5xx response.
+
+    Args:
+        response: Response object with a ``status_code`` attribute.
+        url: Request URL, used to build a redacted message.
+        params: Request params, scanned for secret values to scrub.
+        headers: Request headers, scanned for secret values to scrub.
+        data: Request form body, scanned for secret values to scrub.
+
+    Raises:
+        MoodleHttpError: If the response's status code is 4xx/5xx.
+    """
+    status_code = getattr(response, "status_code", None)
+    if status_code is None or status_code < 400:
+        return
+    secrets = _collect_secrets(url=url, params=params, headers=headers, data=data)
+    body_snippet = _redact_text(_truncate(getattr(response, "text", "")), secrets)
+    redacted_url = _redact_url(url)
+    message = _redact_text(
+        f"Moodle HTTP request to {redacted_url} failed with status "
+        f"{status_code}: {body_snippet}",
+        secrets,
+    )
+    raise MoodleHttpError(message, status_code=status_code, url=redacted_url)
+
+
+def _parse_json(
+    response: Any,
+    *,
+    url: Optional[str] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, Any]] = None,
+) -> Any:
+    """Parse a JSON response body, raising typed exceptions on failure.
+
+    Args:
+        response: Response object exposing ``.json()`` and ``.text``.
+        url: Request URL, used to build a redacted message.
+        params: Request params, scanned for secret values to scrub.
+        headers: Request headers, scanned for secret values to scrub.
+
+    Returns:
+        Any: The parsed JSON payload when it is not a Moodle error shape.
+
+    Raises:
+        MoodleHttpError: If the body is not valid JSON.
+        MoodleWebserviceError: If the body has the Moodle webservice error
+            shape (``exception``/``errorcode``/``message``).
+    """
+    secrets = _collect_secrets(url=url, params=params, headers=headers)
+    status_code = getattr(response, "status_code", None)
+    redacted_url = _redact_url(url)
+    try:
+        data = response.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        body_snippet = _redact_text(_truncate(getattr(response, "text", "")), secrets)
+        message = _redact_text(
+            f"Moodle response from {redacted_url} was not valid JSON: "
+            f"{body_snippet}",
+            secrets,
+        )
+        raise MoodleHttpError(
+            message, status_code=status_code, url=redacted_url
+        ) from exc
+
+    if isinstance(data, dict) and ("exception" in data or "errorcode" in data):
+        message = _redact_text(
+            str(data.get("message", "Unknown Moodle error")), secrets
+        )
+        raise MoodleWebserviceError(
+            message,
+            errorcode=data.get("errorcode"),
+            moodle_exception=data.get("exception"),
+            status_code=status_code,
+            url=redacted_url,
+        )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Public request helpers
+# ---------------------------------------------------------------------------
+
+
+def request_webservice(
+    session: Any,
+    base_url: str,
+    wsfunction: str,
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    token: Optional[str] = None,
+    timeout: Optional[Any] = None,
+    method: str = "post",
+) -> Any:
+    """Call a Moodle webservice REST function and return its parsed payload.
+
+    Args:
+        session: Authenticated ``requests.Session``-like object.
+        base_url: Base URL of the Moodle instance.
+        wsfunction: Name of the Moodle webservice function to call.
+        params: Additional parameters for the webservice call.
+        token: Webservice token, sent as ``wstoken``.
+        timeout: Optional timeout override; defaults to
+            ``DEFAULT_REQUEST_TIMEOUT``.
+        method: HTTP method to use: ``"post"`` (default, never retried,
+            appropriate for most Moodle webservice calls) or ``"get"``
+            (retried with backoff on transient network errors; only use
+            for calls that are safe and idempotent).
+
+    Returns:
+        Any: Parsed JSON payload (typically a ``dict`` or ``list``).
+
+    Raises:
+        MoodleHttpError: On network failures or non-2xx status codes.
+        MoodleTimeoutError: On repeated timeouts for GET-style calls.
+        MoodleWebserviceError: When Moodle returns an error payload.
+    """
+    url = f"{base_url}/webservice/rest/server.php"
+    request_params: Dict[str, Any] = {
+        "moodlewsrestformat": "json",
+        "wsfunction": wsfunction,
+    }
+    if token is not None:
+        request_params["wstoken"] = token
+    request_params.update(params or {})
+
+    effective_timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+    response = _send_request(
+        session,
+        method,
+        url,
+        timeout=effective_timeout,
+        retryable=(method == "get"),
+        params=request_params,
+    )
+    _raise_for_status(response, url=url, params=request_params)
+    return _parse_json(response, url=url, params=request_params)
+
+
+def request_html_get(
+    session: Any,
+    url: str,
+    *,
+    timeout: Optional[Any] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> Any:
+    """Perform a safe, retryable GET request and return the raw response.
+
+    Args:
+        session: Authenticated ``requests.Session``-like object.
+        url: Absolute URL to fetch.
+        timeout: Optional timeout override; defaults to
+            ``DEFAULT_SCRAPE_TIMEOUT``.
+        headers: Optional request headers.
+
+    Returns:
+        The response object returned by the underlying session's ``get``.
+
+    Raises:
+        MoodleHttpError: On non-2xx status codes.
+        MoodleTimeoutError: On repeated timeouts after retries.
+    """
+    effective_timeout = timeout if timeout is not None else DEFAULT_SCRAPE_TIMEOUT
+    response = _send_request(
+        session,
+        "get",
+        url,
+        timeout=effective_timeout,
+        retryable=True,
+        headers=headers,
+    )
+    _raise_for_status(response, url=url, headers=headers)
+    return response
+
+
+def request_form_post(
+    session: Any,
+    url: str,
+    *,
+    data: Optional[Any] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: Optional[Any] = None,
+    allow_redirects: bool = True,
+    raise_for_status: bool = True,
+) -> Any:
+    """Perform a mutating form POST request; never retried automatically.
+
+    Args:
+        session: Authenticated ``requests.Session``-like object.
+        url: Absolute URL to post to.
+        data: Form-encoded body (dict or already-encoded string).
+        headers: Optional request headers.
+        timeout: Optional timeout override; defaults to
+            ``DEFAULT_REQUEST_TIMEOUT``.
+        allow_redirects: Whether to follow redirects (forwarded as-is).
+        raise_for_status: Whether to raise ``MoodleHttpError`` for a
+            4xx/5xx response. Callers that need to inspect Moodle's
+            redirect/form-re-render behavior themselves can pass
+            ``False`` and handle the raw response's status code.
+
+    Returns:
+        The response object returned by the underlying session's ``post``.
+
+    Raises:
+        MoodleHttpError: On network failures (never retried), or on a
+            4xx/5xx status code when ``raise_for_status`` is ``True``.
+    """
+    effective_timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+    response = _send_request(
+        session,
+        "post",
+        url,
+        timeout=effective_timeout,
+        retryable=False,
+        data=data,
+        headers=headers,
+        allow_redirects=allow_redirects,
+    )
+    if raise_for_status:
+        _raise_for_status(response, url=url, headers=headers, data=data)
+    return response
+
+
+def request_ajax(
+    session: Any,
+    url: str,
+    payload: Any,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: Optional[Any] = None,
+) -> Any:
+    """Perform a Moodle ``lib/ajax/service.php`` call and parse its response.
+
+    Args:
+        session: Authenticated ``requests.Session``-like object.
+        url: Absolute AJAX endpoint URL (typically including ``sesskey``).
+        payload: JSON-serializable list of AJAX method-call descriptors.
+        headers: Optional request headers; defaults to
+            ``{"Content-Type": "application/json"}``.
+        timeout: Optional timeout override; defaults to
+            ``DEFAULT_REQUEST_TIMEOUT``.
+
+    Returns:
+        Any: Parsed JSON payload (typically a list of AJAX response
+        entries).
+
+    Raises:
+        MoodleHttpError: On network failures, non-2xx status codes, a
+            non-JSON body, or an AJAX error entry in the response. Never
+            retried, since AJAX calls may be mutating.
+    """
+    effective_timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+    effective_headers = headers or {"Content-Type": "application/json"}
+    response = _send_request(
+        session,
+        "post",
+        url,
+        timeout=effective_timeout,
+        retryable=False,
+        json=payload,
+        headers=effective_headers,
+    )
+    _raise_for_status(response, url=url, headers=effective_headers)
+    data = _parse_json(response, url=url, headers=effective_headers)
+
+    if (
+        isinstance(data, list)
+        and data
+        and isinstance(data[0], dict)
+        and data[0].get("error")
+    ):
+        secrets = _collect_secrets(url=url, headers=effective_headers)
+        exception_payload = data[0].get("exception")
+        if isinstance(exception_payload, dict):
+            message = exception_payload.get("message", "Unknown AJAX error")
+        else:
+            message = (
+                str(exception_payload) if exception_payload else ("Unknown AJAX error")
+            )
+        raise MoodleHttpError(_redact_text(str(message), secrets), url=_redact_url(url))
+    return data
+
+
+def upload_file(
+    url: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    files: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Any] = None,
+) -> Any:
+    """Upload a file via a direct, session-less POST request.
+
+    Mirrors the pattern used by Moodle's webservice file-upload endpoint,
+    which authenticates via a token query parameter rather than session
+    cookies. Never retried, since uploads are mutating requests.
+
+    Args:
+        url: Absolute upload endpoint URL.
+        params: Query parameters (e.g. ``{"token": ..., "filearea": ...}``).
+        files: ``requests``-style ``files`` mapping for multipart upload.
+        timeout: Optional timeout override; defaults to
+            ``DEFAULT_UPLOAD_TIMEOUT``.
+
+    Returns:
+        The raw response returned by ``requests.post``.
+
+    Raises:
+        MoodleHttpError: On network failures or non-2xx status codes.
+    """
+    effective_timeout = timeout if timeout is not None else DEFAULT_UPLOAD_TIMEOUT
+    response = _send_request(
+        requests,
+        "post",
+        url,
+        timeout=effective_timeout,
+        retryable=False,
+        params=params,
+        files=files,
+    )
+    _raise_for_status(response, url=url, params=params)
+    return response
+
+
+__all__ = [
+    "MoodleHttpError",
+    "MoodleTimeoutError",
+    "MoodleWebserviceError",
+    "REDACTED",
+    "request_ajax",
+    "request_form_post",
+    "request_html_get",
+    "request_webservice",
+    "upload_file",
+]

--- a/src/py_moodle/session.py
+++ b/src/py_moodle/session.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 from .auth import LoginError, login
 from .compat import DEFAULT_COMPATIBILITY, get_session_compatibility
 from .config import DEFAULT_REQUEST_TIMEOUT
+from .http import MoodleHttpError, MoodleWebserviceError, request_webservice
 
 
 class MoodleSessionError(RuntimeError):
@@ -131,30 +132,26 @@ class MoodleSession:
         if params is None:
             params = {}
 
-        request_params = {
-            "moodlewsrestformat": "json",
-            "wsfunction": wsfunction,
-            "wstoken": self.token,
-            **params,
-        }
-
-        response = self.session.post(
-            f"{self.settings.url}/webservice/rest/server.php",
-            params=request_params,
-            timeout=DEFAULT_REQUEST_TIMEOUT,
-        )
-        response.raise_for_status()
-        data = response.json()
-        # Check for Moodle-specific error response
-        if isinstance(data, dict) and (
-            "exception" in data or "errorcode" in data or "message" in data
-        ):
+        try:
+            return request_webservice(
+                self.session,
+                self.settings.url,
+                wsfunction,
+                params,
+                token=self.token,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
+            )
+        except MoodleWebserviceError as exc:
             raise MoodleSessionError(
                 f"Moodle API call {wsfunction!r} failed: "
-                f"{data.get('message', 'Unknown error')} "
-                f"(errorcode: {data.get('errorcode', 'N/A')}, exception: {data.get('exception', 'N/A')})"
-            )
-        return data
+                f"{exc.args[0] if exc.args else 'Unknown error'} "
+                f"(errorcode: {exc.errorcode or 'N/A'}, "
+                f"exception: {exc.moodle_exception or 'N/A'})"
+            ) from exc
+        except MoodleHttpError as exc:
+            raise MoodleSessionError(
+                f"Moodle API call {wsfunction!r} failed: {exc}"
+            ) from exc
 
     # ------------- factory -------------
     @classmethod

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,0 +1,411 @@
+"""Unit tests for the centralized HTTP layer in ``py_moodle.http``."""
+
+import json
+
+import pytest
+import requests
+
+from py_moodle.config import DEFAULT_REQUEST_TIMEOUT, DEFAULT_SCRAPE_TIMEOUT
+from py_moodle.http import (
+    MoodleHttpError,
+    MoodleTimeoutError,
+    MoodleWebserviceError,
+    request_ajax,
+    request_form_post,
+    request_html_get,
+    request_webservice,
+    upload_file,
+)
+
+FAKE_TOKEN = "fake-wstoken-abcdef0123456789"
+FAKE_SESSKEY = "fake-sesskey-9f8e7d6c"
+FAKE_PASSWORD = "fake-Sup3rSecret!"
+FAKE_AUTH_HEADER = "Bearer fake-auth-token-zzzz9999"
+FAKE_COOKIE = "MoodleSession=fake-cookie-value-1234"
+
+
+class StubResponse:
+    """Minimal ``requests.Response``-like object for deterministic tests."""
+
+    def __init__(self, *, status_code=200, text="", json_data=None, json_error=None):
+        self.status_code = status_code
+        self.text = text
+        self._json_data = json_data
+        self._json_error = json_error
+
+    def json(self):
+        """Return the configured JSON payload or raise the configured error."""
+        if self._json_error is not None:
+            raise self._json_error
+        return self._json_data
+
+
+class StubSession:
+    """Records GET/POST calls and returns canned or raised results."""
+
+    def __init__(self, *, get_result=None, post_result=None):
+        self.get_result = get_result
+        self.post_result = post_result
+        self.get_calls = []
+        self.post_calls = []
+
+    def get(self, url, **kwargs):
+        """Record a GET call and return or raise the configured result."""
+        self.get_calls.append({"url": url, "kwargs": kwargs})
+        return self._resolve(self.get_result)
+
+    def post(self, url, **kwargs):
+        """Record a POST call and return or raise the configured result."""
+        self.post_calls.append({"url": url, "kwargs": kwargs})
+        return self._resolve(self.post_result)
+
+    @staticmethod
+    def _resolve(result):
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class AlwaysRaisingSession:
+    """Session whose GET/POST always raise the given exception, forever."""
+
+    def __init__(self, exc_factory):
+        self.exc_factory = exc_factory
+        self.get_calls = 0
+        self.post_calls = 0
+
+    def get(self, url, **kwargs):
+        """Record the call and always raise."""
+        self.get_calls += 1
+        raise self.exc_factory()
+
+    def post(self, url, **kwargs):
+        """Record the call and always raise."""
+        self.post_calls += 1
+        raise self.exc_factory()
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_request_webservice_success_returns_json_with_default_timeout():
+    """A successful webservice call returns the parsed JSON body unchanged."""
+    session = StubSession(
+        post_result=StubResponse(json_data={"id": 1, "fullname": "Course"})
+    )
+
+    result = request_webservice(
+        session,
+        "https://moodle.example.test",
+        "core_course_get_courses",
+        token="tok",
+    )
+
+    assert result == {"id": 1, "fullname": "Course"}
+    assert session.post_calls[0]["kwargs"]["timeout"] == DEFAULT_REQUEST_TIMEOUT
+
+
+def test_request_webservice_uses_timeout_override():
+    """An explicit timeout override takes precedence over the default."""
+    session = StubSession(post_result=StubResponse(json_data={"ok": True}))
+
+    request_webservice(
+        session,
+        "https://moodle.example.test",
+        "core_course_get_courses",
+        token="tok",
+        timeout=5,
+    )
+
+    assert session.post_calls[0]["kwargs"]["timeout"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Retry behavior
+# ---------------------------------------------------------------------------
+
+
+def test_request_html_get_retries_on_timeout_then_raises_moodle_timeout_error():
+    """GET-style requests retry on transient timeouts before failing."""
+    session = AlwaysRaisingSession(requests.exceptions.Timeout)
+
+    with pytest.raises(MoodleTimeoutError):
+        request_html_get(session, "https://moodle.example.test/course/view.php?id=1")
+
+    assert session.get_calls > 1  # retried at least once
+    assert session.get_calls == session.get_calls  # sanity, count is bounded
+    assert session.get_calls <= 5  # small, bounded number of attempts
+
+
+def test_request_html_get_retries_on_connection_error_then_raises():
+    """GET-style requests also retry on connection errors."""
+    session = AlwaysRaisingSession(requests.exceptions.ConnectionError)
+
+    with pytest.raises(MoodleHttpError):
+        request_html_get(session, "https://moodle.example.test/course/view.php?id=1")
+
+    assert session.get_calls > 1
+
+
+def test_request_form_post_network_error_raises_immediately_without_retry():
+    """POST-style (mutating) requests are never retried automatically."""
+    session = AlwaysRaisingSession(requests.exceptions.ConnectionError)
+
+    with pytest.raises(MoodleHttpError):
+        request_form_post(session, "https://moodle.example.test/course/edit.php")
+
+    assert session.post_calls == 1
+
+
+def test_request_webservice_post_timeout_raises_immediately_without_retry():
+    """A webservice call sent as POST is never retried on timeout."""
+    session = AlwaysRaisingSession(requests.exceptions.Timeout)
+
+    with pytest.raises(MoodleTimeoutError):
+        request_webservice(
+            session, "https://moodle.example.test", "core_course_get_courses"
+        )
+
+    assert session.post_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTP status codes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status_code", [404, 500])
+def test_request_webservice_http_error_status_raises_with_status_code(status_code):
+    """4xx/5xx responses raise MoodleHttpError carrying the status code."""
+    session = StubSession(
+        post_result=StubResponse(status_code=status_code, text="Server error")
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_webservice(
+            session, "https://moodle.example.test", "core_course_get_courses"
+        )
+
+    assert excinfo.value.status_code == status_code
+
+
+# ---------------------------------------------------------------------------
+# Non-JSON body
+# ---------------------------------------------------------------------------
+
+
+def test_request_webservice_invalid_json_raises_typed_error_not_json_decode_error():
+    """A non-JSON 200 body raises a typed exception instead of JSONDecodeError."""
+    session = StubSession(
+        post_result=StubResponse(
+            json_error=json.JSONDecodeError("Expecting value", "<html>oops</html>", 0)
+        )
+    )
+
+    with pytest.raises(MoodleHttpError):
+        request_webservice(
+            session, "https://moodle.example.test", "core_course_get_courses"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Moodle webservice error payload
+# ---------------------------------------------------------------------------
+
+
+def test_request_webservice_moodle_error_payload_raises_typed_error():
+    """A Moodle webservice error body raises MoodleWebserviceError with fields."""
+    session = StubSession(
+        post_result=StubResponse(
+            json_data={
+                "exception": "moodle_exception",
+                "errorcode": "invalidtoken",
+                "message": "Invalid token - token not found",
+            }
+        )
+    )
+
+    with pytest.raises(MoodleWebserviceError) as excinfo:
+        request_webservice(
+            session, "https://moodle.example.test", "core_course_get_courses"
+        )
+
+    assert excinfo.value.errorcode == "invalidtoken"
+    assert "Invalid token" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_wstoken_from_params_on_failure():
+    """A webservice token passed as a request param never leaks into errors."""
+    session = StubSession(
+        post_result=StubResponse(
+            status_code=500, text=f"Server error for token {FAKE_TOKEN}"
+        )
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_webservice(
+            session,
+            "https://moodle.example.test",
+            "core_course_get_courses",
+            token=FAKE_TOKEN,
+        )
+
+    exc = excinfo.value
+    assert FAKE_TOKEN not in str(exc)
+    assert FAKE_TOKEN not in repr(exc)
+    assert all(FAKE_TOKEN not in str(a) for a in exc.args)
+
+
+def test_redacts_sesskey_embedded_in_url_on_failure():
+    """A sesskey embedded directly in the URL never leaks into errors."""
+    session = AlwaysRaisingSession(requests.exceptions.ConnectionError)
+    url = f"https://moodle.example.test/lib/ajax/service.php?sesskey={FAKE_SESSKEY}"
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_ajax(session, url, [{"index": 0, "methodname": "x", "args": {}}])
+
+    exc = excinfo.value
+    assert FAKE_SESSKEY not in str(exc)
+    assert FAKE_SESSKEY not in repr(exc)
+    assert all(FAKE_SESSKEY not in str(a) for a in exc.args)
+    if exc.url:
+        assert FAKE_SESSKEY not in exc.url
+
+
+def test_redacts_password_from_form_post_data_on_failure():
+    """A password passed as form data never leaks into raised errors."""
+    session = StubSession(
+        post_result=StubResponse(
+            status_code=403, text=f"Forbidden, password={FAKE_PASSWORD} rejected"
+        )
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_form_post(
+            session,
+            "https://moodle.example.test/login/index.php",
+            data={"username": "user", "password": FAKE_PASSWORD},
+        )
+
+    exc = excinfo.value
+    assert FAKE_PASSWORD not in str(exc)
+    assert FAKE_PASSWORD not in repr(exc)
+    assert all(FAKE_PASSWORD not in str(a) for a in exc.args)
+
+
+def test_redacts_authorization_header_on_failure():
+    """An Authorization header value never leaks into raised errors."""
+    session = StubSession(
+        post_result=StubResponse(
+            status_code=401, text=f"Rejected header Authorization: {FAKE_AUTH_HEADER}"
+        )
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_form_post(
+            session,
+            "https://moodle.example.test/webservice/rest/server.php",
+            headers={"Authorization": FAKE_AUTH_HEADER},
+        )
+
+    exc = excinfo.value
+    assert FAKE_AUTH_HEADER not in str(exc)
+    assert FAKE_AUTH_HEADER not in repr(exc)
+    assert all(FAKE_AUTH_HEADER not in str(a) for a in exc.args)
+
+
+def test_redacts_cookie_header_on_failure():
+    """A Cookie header value never leaks into raised errors."""
+    session = StubSession(
+        post_result=StubResponse(
+            status_code=403, text=f"Rejected cookie: {FAKE_COOKIE}"
+        )
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_form_post(
+            session,
+            "https://moodle.example.test/course/edit.php",
+            headers={"Cookie": FAKE_COOKIE},
+        )
+
+    exc = excinfo.value
+    assert FAKE_COOKIE not in str(exc)
+    assert FAKE_COOKIE not in repr(exc)
+    assert all(FAKE_COOKIE not in str(a) for a in exc.args)
+
+
+# ---------------------------------------------------------------------------
+# request_ajax and upload_file smoke coverage
+# ---------------------------------------------------------------------------
+
+
+def test_request_ajax_returns_data_on_success():
+    """A successful AJAX call returns the parsed JSON payload."""
+    session = StubSession(
+        post_result=StubResponse(json_data=[{"error": False, "data": "[]"}])
+    )
+
+    result = request_ajax(
+        session,
+        "https://moodle.example.test/lib/ajax/service.php?sesskey=abc",
+        [{"index": 0, "methodname": "core_course_get_courses", "args": {}}],
+    )
+
+    assert result == [{"error": False, "data": "[]"}]
+
+
+def test_request_ajax_raises_on_ajax_error_shape():
+    """An AJAX error entry raises a typed exception with the error message."""
+    session = StubSession(
+        post_result=StubResponse(
+            json_data=[{"error": True, "exception": {"message": "Access denied"}}]
+        )
+    )
+
+    with pytest.raises(MoodleHttpError) as excinfo:
+        request_ajax(
+            session,
+            "https://moodle.example.test/lib/ajax/service.php?sesskey=abc",
+            [{"index": 0, "methodname": "core_course_get_courses", "args": {}}],
+        )
+
+    assert "Access denied" in str(excinfo.value)
+
+
+def test_upload_file_uses_default_upload_timeout(monkeypatch):
+    """upload_file applies the shared upload timeout by default."""
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append({"url": url, "kwargs": kwargs})
+        return StubResponse(json_data=[{"itemid": 42}])
+
+    monkeypatch.setattr("py_moodle.http.requests.post", fake_post)
+
+    from py_moodle.config import DEFAULT_UPLOAD_TIMEOUT
+
+    response = upload_file(
+        "https://moodle.example.test/webservice/upload.php",
+        params={"token": "tok"},
+        files={"file": ("demo.txt", b"data", "text/plain")},
+    )
+
+    assert response.json() == [{"itemid": 42}]
+    assert calls[0]["kwargs"]["timeout"] == DEFAULT_UPLOAD_TIMEOUT
+
+
+def test_request_html_get_uses_scrape_timeout_by_default():
+    """request_html_get defaults to the shared scrape timeout."""
+    session = StubSession(get_result=StubResponse(text="<html></html>"))
+
+    request_html_get(session, "https://moodle.example.test/course/view.php?id=1")
+
+    assert session.get_calls[0]["kwargs"]["timeout"] == DEFAULT_SCRAPE_TIMEOUT


### PR DESCRIPTION
## Summary
Adds a new `src/py_moodle/http.py` module that becomes the single place responsible for HTTP timeout policy, conservative retries, typed exceptions, Moodle webservice error-payload parsing, and secret redaction when talking to Moodle. As proof of adoption, `session.py`'s `MoodleSession.call()` and `course.py`'s `list_courses()`/`create_course()` are migrated onto it, with no observable behavior change for their existing callers.

## Linked issue
Closes #39

## Specification
- **Timeout policy**: every request through the new module uses the existing `config.py` constants (`DEFAULT_REQUEST_TIMEOUT`, `DEFAULT_SCRAPE_TIMEOUT`, `DEFAULT_UPLOAD_TIMEOUT`) by default, with an optional override.
- **Conservative retries**: safe, idempotent GET-style requests (`request_html_get`) retry a small, bounded number of times with backoff on `requests.exceptions.ConnectionError`/`Timeout`. POST/mutating requests (`request_form_post`, `request_ajax`, `upload_file`, and `request_webservice`'s default `method="post"`) are never retried automatically.
- **Typed exceptions**: `MoodleHttpError` (base), `MoodleTimeoutError` (timeouts/connection failures after retries), and `MoodleWebserviceError` (Moodle webservice error payloads, carrying `errorcode`/`moodle_exception`). These are additive — none of the 17 existing per-module exceptions are removed or renamed.
- **Secret redaction**: known secret-shaped values (`wstoken`/`token`, `sesskey`, `password`, `Authorization` header, `Cookie`/`Set-Cookie` header) are stripped from the URL, params, headers, and response-body text used to build any exception message, so `str()`/`repr()`/`args` of a raised exception never contain them.
- **Moodle webservice error parsing**: a shared helper inspects parsed JSON bodies for the `exception`/`errorcode`/`message` shape and raises `MoodleWebserviceError` with those fields populated, instead of leaving each caller to `.get()` those keys itself.

## Implementation details
- `src/py_moodle/http.py` (new): `MoodleHttpError`, `MoodleTimeoutError`, `MoodleWebserviceError`; `request_webservice()`, `request_html_get()`, `request_form_post()`, `request_ajax()`, `upload_file()`; internal `_send_request()` (timeout + retry policy), `_raise_for_status()`, `_parse_json()`, and redaction helpers (`_collect_secrets()`, `_redact_url()`, `_redact_text()`, `_truncate()`).
- `src/py_moodle/session.py`: `MoodleSession.call()` now delegates its request/response handling to `request_webservice()`, catching `MoodleWebserviceError`/`MoodleHttpError` and re-raising as `MoodleSessionError` with the same message shape callers already depend on (wsfunction name, Moodle `message`, `errorcode`, `exception`).
- `src/py_moodle/course.py`: `list_courses()`'s webservice attempt and AJAX fallback now go through `request_webservice()`/`request_html_get()`/`request_ajax()` (any webservice failure still falls back to AJAX, matching prior behavior); `create_course()`'s form POST to `course/edit.php` now goes through `request_form_post()` (with `raise_for_status=False` so its existing 200/302/303/other status-code handling is unchanged), wrapped to re-raise `MoodleHttpError` as `MoodleCourseError`.
- `tests/unit/test_http.py` (new): 19 tests covering success + default timeout, timeout override, GET retry-then-`MoodleTimeoutError`, GET retry-then-`MoodleHttpError` (connection error), POST no-retry (webservice and form-post), 404/5xx → `MoodleHttpError` with `status_code`, non-JSON body → typed error (not `JSONDecodeError`), Moodle webservice error payload → `MoodleWebserviceError` with `errorcode`, and one redaction test per secret kind (`wstoken` in params, `sesskey` embedded in a URL, `password` in form data, `Authorization` header, `Cookie` header) plus `request_ajax`/`upload_file` smoke coverage.
- `docs/api/http.md` (new) + `mkdocs.yml` nav entry so mkdocstrings publishes the new module's docstrings.
- `docs/development.md`: short note pointing contributors at `http.py` as the preferred way to make new HTTP requests.

## Test plan
- [x] Added failing tests first.
- [x] Confirmed the tests failed before implementation.
- [x] Implemented the feature/refactor.
- [x] Confirmed the focused tests pass.
- [x] Confirmed the full "pytest tests/unit" suite passes.

Commands run:
```bash
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit/test_http.py -q   # red: ModuleNotFoundError: No module named 'py_moodle.http'
# implement src/py_moodle/http.py
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit/test_http.py -q   # green: 19 passed
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit/test_timeouts.py tests/unit/test_error_messages.py -q  # 8 passed, unmodified
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/pytest tests/unit -q                # 57 passed
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/black --check src tests
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/isort --check-only src tests
/Users/ernesto/Dropbox/Trabajo/git/python-moodle/.venv/bin/flake8
```

## Backward compatibility
Purely additive at the library boundary: a new module and new exception types, no existing public function signature, CLI command, `src/py_moodle/__init__.py` export, or `config.py` constant changes. `MoodleSession.call()` still raises `LoginError` (missing token) and `MoodleSessionError` (webservice error / HTTP failure) exactly as before — verified by `tests/unit/test_error_messages.py` and `tests/unit/test_timeouts.py` passing unmodified. `list_courses()`/`create_course()` keep their signatures, return shapes, and `MoodleCourseError` exception type. Modules not migrated in this issue (`folder.py`, `scorm.py`, `section.py`, `user.py`, `draftfile.py`, `category.py`, `auth.py`, `module.py`, `compat.py`, `upload.py`) are completely unaffected.

## Documentation
- Added `docs/api/http.md` and an `mkdocs.yml` nav entry so the new module's docstrings are published like other modules (`session.py`, `config.py`, etc.).
- Added a short "Making HTTP Requests" note in `docs/development.md` pointing new contributors at `http.py`.
- No `docs/cli.md` changes: no CLI-facing behavior changed (no CLI files touched).

## Risk assessment
- **Low risk**: only 2 modules touched at the call-site level (`session.py`, `course.py`), both with existing unit-test coverage that passes unmodified.
- The webservice-attempt-then-AJAX-fallback path in `list_courses()` now also silently falls back to AJAX on a *network* failure during the webservice attempt (previously such a network error would propagate uncaught, since it happened outside the original `try` block — an existing latent gap). This is a deliberate, low-risk resilience improvement consistent with the issue's motivation, and is not covered by any existing test that would need to change.
- `create_course()`'s POST to `course/edit.php` now has a default timeout applied (`DEFAULT_REQUEST_TIMEOUT`) where none existed before; this is an intentional part of centralizing the timeout policy.

## Manual verification
```python
from unittest.mock import MagicMock
from py_moodle.http import request_webservice, MoodleWebserviceError

session = MagicMock()
session.post.return_value.status_code = 200
session.post.return_value.json.return_value = {
    "exception": "moodle_exception",
    "errorcode": "invalidtoken",
    "message": "Invalid token - token not found",
}

try:
    request_webservice(session, "https://moodle.example.test", "core_course_get_courses", token="fake-token-123")
except MoodleWebserviceError as e:
    print(e.errorcode)   # "invalidtoken"
    print(str(e))         # "Invalid token - token not found"  (no "fake-token-123" leaked)
```
Also exercised via `tests/unit/test_http.py` (mocked, no live Moodle instance required).

## Notes for reviewers
- Only `session.py`'s `call()` and `course.py`'s `list_courses()`/`create_course()` are migrated, per the issue's explicit scope. Migrating the remaining ~10-12 modules (`folder.py`, `scorm.py`, `section.py`, `user.py`, `draftfile.py`, `category.py`, `auth.py`, `module.py`, `compat.py`, and `upload.py`'s direct `requests.post`) is intentionally deferred to follow-up issues, as called out in the issue itself.
- `http.py` provides an `upload_file()` helper (covered by its own unit test) to satisfy the acceptance criterion that the module expose a file-upload helper, but `upload.py` itself is **not** migrated to use it in this PR — that's part of the deferred follow-up work, not a partial/broken migration.
- The 17 existing per-module exception classes (`MoodleCourseError`, `MoodleSessionError`, etc.) are intentionally left as-is; consolidating them is explicitly out of scope for this issue.
- This branch is intended as the base for the follow-up "transport strategies" issue (#40); the public names in `http.py` (`request_webservice`, `request_html_get`, `request_form_post`, `request_ajax`, `upload_file`, `MoodleHttpError`, `MoodleTimeoutError`, `MoodleWebserviceError`) were chosen to be stable for that purpose.