### PR TITLE
Split Moodle transport strategies: webservice, AJAX, HTML

### DIFF
--- a/docs/api/transport.md
+++ b/docs/api/transport.md
@@ -1,0 +1,9 @@
+# Transport
+
+::: py_moodle.transport
+
+::: py_moodle.transport.webservice
+
+::: py_moodle.transport.ajax
+
+::: py_moodle.transport.html

--- a/docs/development.md
+++ b/docs/development.md
@@ -110,6 +110,31 @@ sites have been migrated so far (`session.py`'s `MoodleSession.call()` and
 `course.py`'s `list_courses()`/`create_course()`); migrating the remaining
 modules is tracked as follow-up work.
 
+### Transport Strategies
+
+`src/py_moodle/transport/` formalizes the three ways `py-moodle` talks to
+Moodle as explicit, independently testable strategy modules built on top
+of `http.py`:
+
+- `transport/webservice.py` — the webservice/REST API transport
+  (`{base_url}/webservice/rest/server.php` with a `wstoken`).
+- `transport/ajax.py` — the internal AJAX endpoint transport
+  (`{base_url}/lib/ajax/service.php?sesskey=...`).
+- `transport/html.py` — an interface-only placeholder for a future
+  HTML-scraping/form-submission transport (e.g. `course/edit.php`).
+
+Both `webservice.call(...)` and `ajax.call(...)` raise
+`transport.TransportUnavailableError` when that specific transport cannot
+be used for the call (invalid/expired token, missing `sesskey`), letting a
+caller fall back to the next transport in the chain, and
+`transport.TransportError` for any other failure. `course.py`'s
+`list_courses()` has been migrated as a proof of concept to use these two
+transports instead of inlining the webservice/AJAX request-building and
+fallback logic itself; migrating the remaining webservice/AJAX call sites
+(`get_course_state`, and the AJAX calls in `section.py`, `module.py`,
+`draftfile.py`) onto the same transport modules is tracked as follow-up
+work.
+
 ## Testing
 
 ### Running Tests

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Core:
       - Session: api/session.md
       - HTTP: api/http.md
+      - Transport: api/transport.md
       - Settings: api/settings.md
       - Auth: api/auth.md
     - Course Management:

--- a/src/py_moodle/course.py
+++ b/src/py_moodle/course.py
@@ -14,14 +14,11 @@ from typing import Any, Dict, List
 
 import requests
 
-from .http import (
-    MoodleHttpError,
-    request_ajax,
-    request_form_post,
-    request_html_get,
-    request_webservice,
-)
+from .http import MoodleHttpError, request_form_post
 from .permissions import requires_role
+from .transport import TransportError, TransportUnavailableError
+from .transport import ajax as ajax_transport
+from .transport import webservice as webservice_transport
 
 
 class MoodleCourseError(Exception):
@@ -78,7 +75,13 @@ def list_courses(
     """List all courses visible to the user.
 
     Uses the ``core_course_get_courses`` webservice when a token is
-    available and falls back to the AJAX endpoint otherwise.
+    available and falls back to the AJAX endpoint otherwise. Internally,
+    each transport is delegated to :mod:`py_moodle.transport.webservice`
+    and :mod:`py_moodle.transport.ajax` respectively; their
+    ``TransportError``/``TransportUnavailableError`` exceptions are
+    translated into ``MoodleCourseError`` (or used to decide the
+    webservice-to-AJAX fallback) and never leak to callers of this
+    function.
 
     Args:
         session: Authenticated requests session.
@@ -98,20 +101,19 @@ def list_courses(
     if sesskey is None and hasattr(session, "sesskey"):
         sesskey = getattr(session, "sesskey", None)
 
-    # If token is present but invalid (or the call otherwise fails), fall
-    # back to the AJAX endpoint below.
     if token:
         try:
-            result = request_webservice(
-                session, base_url, "core_course_get_courses", token=token
+            result = webservice_transport.call(
+                session, base_url, "core_course_get_courses", token
             )
             # Sort by ID ascending before returning
             return sorted(result, key=lambda c: c.get("id", 0))
-        except Exception:
-            # Any webservice failure (invalid token, transient network
-            # error, unexpected payload shape, or a Moodle-reported error)
-            # falls back to the AJAX endpoint below.
+        except TransportUnavailableError:
+            # The token is invalid/expired: fall through to the AJAX
+            # transport below.
             pass
+        except TransportError as exc:
+            raise MoodleCourseError(str(exc)) from exc
 
     if not sesskey:
         raise MoodleCourseError(
@@ -120,21 +122,14 @@ def list_courses(
             "web service."
         )
 
-    # Refresh session before AJAX call to prevent "session expired" errors.
-    request_html_get(session, f"{base_url}/my/")
-
-    url = f"{base_url}/lib/ajax/service.php?sesskey={sesskey}"
-    payload = [{"index": 0, "methodname": "core_course_get_courses", "args": {}}]
     try:
-        result = request_ajax(session, url, payload)
-        # The data is in result[0]["data"]
-        courses = result[0]["data"]
+        result = ajax_transport.call(
+            session, base_url, "core_course_get_courses", sesskey
+        )
         # Sort by ID ascending before returning
-        return sorted(courses, key=lambda c: c.get("id", 0))
-    except MoodleHttpError as e:
-        raise MoodleCourseError(f"Failed to list courses: {e}") from e
-    except Exception as e:
-        raise MoodleCourseError(f"Failed to parse courses: {e}") from e
+        return sorted(result, key=lambda c: c.get("id", 0))
+    except TransportError as exc:
+        raise MoodleCourseError(str(exc)) from exc
 
 
 @requires_role("manager")

--- a/src/py_moodle/transport/__init__.py
+++ b/src/py_moodle/transport/__init__.py
@@ -1,0 +1,43 @@
+"""Transport-layer abstractions for talking to Moodle.
+
+``py-moodle`` talks to a Moodle instance through three fundamentally
+different transports:
+
+1. **Webservice / REST API** (:mod:`py_moodle.transport.webservice`) --
+   ``POST {base_url}/webservice/rest/server.php`` with a ``wstoken``, e.g.
+   ``core_course_get_courses``.
+2. **Internal AJAX endpoint** (:mod:`py_moodle.transport.ajax`) --
+   ``POST {base_url}/lib/ajax/service.php?sesskey=...`` with a JSON
+   ``methodname``/``args`` payload, used when no webservice token is
+   available or the webservice call fails.
+3. **HTML scraping / form submission** (:mod:`py_moodle.transport.html`) --
+   used where Moodle exposes no webservice or AJAX equivalent at all.
+
+This package formalizes those transports as small, uniform ``call(...)``
+functions built strictly on top of the shared HTTP client in
+:mod:`py_moodle.http`, so a caller can implement "try transport A, on
+failure fall back to transport B" without knowing the request-building
+details of either transport.
+
+Transport (webservice vs AJAX vs HTML) is a different, orthogonal axis from
+Moodle-version compatibility, which remains isolated in
+:mod:`py_moodle.compat`.
+"""
+
+from __future__ import annotations
+
+
+class TransportError(Exception):
+    """Base class for transport-layer errors."""
+
+
+class TransportUnavailableError(TransportError):
+    """Raised when a transport cannot be used for this call.
+
+    Signals to the caller that it should try the next transport in the
+    fallback chain (e.g. webservice -> AJAX), as opposed to a genuine
+    business-logic failure that should propagate to the user.
+    """
+
+
+__all__ = ["TransportError", "TransportUnavailableError"]

--- a/src/py_moodle/transport/ajax.py
+++ b/src/py_moodle/transport/ajax.py
@@ -1,0 +1,64 @@
+"""Internal AJAX endpoint transport strategy for talking to Moodle.
+
+Calls ``{base_url}/lib/ajax/service.php?sesskey=...`` with the
+``[{"index": 0, "methodname": ..., "args": ...}]`` envelope Moodle expects,
+delegating the actual socket-level requests to the shared HTTP client in
+:mod:`py_moodle.http`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from ..http import MoodleHttpError, request_ajax, request_html_get
+from . import TransportError, TransportUnavailableError
+
+
+def call(
+    session: requests.Session,
+    base_url: str,
+    methodname: str,
+    sesskey: str,
+    args: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Call a Moodle method via the internal AJAX endpoint.
+
+    Args:
+        session: Authenticated requests session.
+        base_url: Base URL of the Moodle instance.
+        methodname: Name of the AJAX method to invoke (as used in
+            ``lib/ajax/service.php``).
+        sesskey: Moodle session key required by the AJAX endpoint.
+        args: Additional method arguments.
+
+    Returns:
+        Any: The parsed ``data`` payload from the first entry of the AJAX
+            JSON-array response, on success.
+
+    Raises:
+        TransportUnavailableError: If no usable ``sesskey`` is supplied.
+        TransportError: If the HTTP call fails, or Moodle's AJAX response
+            reports an error for the requested method.
+    """
+    if not sesskey:
+        raise TransportUnavailableError("AJAX transport requires a valid sesskey.")
+
+    # Refresh the session before the AJAX call to prevent "session expired"
+    # errors that have been observed against real Moodle instances.
+    try:
+        request_html_get(session, f"{base_url}/my/")
+    except MoodleHttpError as exc:
+        raise TransportError(str(exc)) from exc
+
+    url = f"{base_url}/lib/ajax/service.php?sesskey={sesskey}"
+    payload = [{"index": 0, "methodname": methodname, "args": args or {}}]
+    try:
+        result = request_ajax(session, url, payload)
+        return result[0]["data"]
+    except MoodleHttpError as exc:
+        raise TransportError(str(exc)) from exc
+
+
+__all__ = ["call"]

--- a/src/py_moodle/transport/html.py
+++ b/src/py_moodle/transport/html.py
@@ -1,0 +1,52 @@
+"""HTML scraping / form-submission transport strategy (interface only).
+
+This module formalizes the calling convention for a future
+``HtmlTransport`` that talks to Moodle by scraping HTML pages and
+submitting HTML forms (e.g. ``course/edit.php``), for the cases where
+Moodle exposes neither a webservice nor an AJAX equivalent.
+
+No real Moodle interaction is wired up as part of this issue: :func:`call`
+only documents the intended signature and always raises
+:class:`NotImplementedError`. Migrating existing HTML-based flows (e.g.
+``create_course``/``delete_course`` in :mod:`py_moodle.course`) onto this
+transport is tracked as follow-up work.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+
+def call(
+    session: requests.Session,
+    base_url: str,
+    action: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Perform an HTML form-submission/scraping call against Moodle.
+
+    Args:
+        session: Authenticated requests session.
+        base_url: Base URL of the Moodle instance.
+        action: Relative path of the HTML page/form to interact with
+            (e.g. ``"course/edit.php"``).
+        params: Form fields or query parameters for the request.
+
+    Returns:
+        Any: Parsed result of the HTML interaction, in whatever shape a
+        future concrete implementation defines.
+
+    Raises:
+        NotImplementedError: Always, for this issue. This module only
+            formalizes the transport interface; no real HTML-based Moodle
+            interaction is implemented yet.
+    """
+    raise NotImplementedError(
+        "HtmlTransport is interface-only in this version of py-moodle; no "
+        "HTML transport is implemented yet."
+    )
+
+
+__all__ = ["call"]

--- a/src/py_moodle/transport/webservice.py
+++ b/src/py_moodle/transport/webservice.py
@@ -1,0 +1,59 @@
+"""Webservice (REST API) transport strategy for talking to Moodle.
+
+Calls ``{base_url}/webservice/rest/server.php`` with a ``wstoken``,
+delegating the actual socket-level request to the shared HTTP client in
+:mod:`py_moodle.http`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from ..http import MoodleHttpError, MoodleWebserviceError, request_webservice
+from . import TransportError, TransportUnavailableError
+
+#: Substring (case-insensitive) that identifies an invalid/expired token
+#: Moodle exception, distinguishing "try another transport" from a genuine
+#: webservice-level failure.
+_INVALID_TOKEN_MARKER = "invalid token"
+
+
+def call(
+    session: requests.Session,
+    base_url: str,
+    wsfunction: str,
+    token: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Call a Moodle webservice function via the REST API.
+
+    Args:
+        session: Authenticated requests session.
+        base_url: Base URL of the Moodle instance.
+        wsfunction: Name of the webservice function to invoke.
+        token: Webservice token (``wstoken``).
+        params: Additional parameters for the webservice call.
+
+    Returns:
+        Any: The parsed JSON response (list or dict) on success.
+
+    Raises:
+        TransportUnavailableError: If Moodle reports an invalid/expired
+            token, indicating the caller should fall back to another
+            transport.
+        TransportError: If the call fails for any other reason (network
+            error, non-token Moodle exception, invalid JSON).
+    """
+    try:
+        return request_webservice(session, base_url, wsfunction, params, token=token)
+    except MoodleWebserviceError as exc:
+        if _INVALID_TOKEN_MARKER in str(exc).lower():
+            raise TransportUnavailableError(str(exc)) from exc
+        raise TransportError(str(exc)) from exc
+    except MoodleHttpError as exc:
+        raise TransportError(str(exc)) from exc
+
+
+__all__ = ["call"]

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -1,0 +1,189 @@
+"""Unit tests for the transport strategy modules in ``py_moodle.transport``."""
+
+import pytest
+
+from py_moodle.course import MoodleCourseError, list_courses
+from py_moodle.transport import TransportError, TransportUnavailableError
+from py_moodle.transport import ajax as ajax_transport
+from py_moodle.transport import webservice as webservice_transport
+
+FAKE_TOKEN = "fake-wstoken-abcdef0123456789"
+FAKE_SESSKEY = "fake-sesskey-9f8e7d6c"
+BASE_URL = "https://moodle.example.test"
+
+
+class StubResponse:
+    """Minimal ``requests.Response``-like object for deterministic tests."""
+
+    def __init__(self, *, status_code=200, text="", json_data=None):
+        self.status_code = status_code
+        self.text = text
+        self._json_data = json_data
+
+    def json(self):
+        """Return the configured JSON payload."""
+        return self._json_data
+
+
+class StubSession:
+    """Records GET/POST calls and dispatches canned responses by URL."""
+
+    def __init__(self, *, get_result=None, post_result=None, post_dispatch=None):
+        self.get_result = get_result
+        self.post_result = post_result
+        self.post_dispatch = post_dispatch or {}
+        self.get_calls = []
+        self.post_calls = []
+
+    def get(self, url, **kwargs):
+        """Record a GET call and return the configured result."""
+        self.get_calls.append({"url": url, "kwargs": kwargs})
+        return self.get_result
+
+    def post(self, url, **kwargs):
+        """Record a POST call and return a result dispatched by URL prefix."""
+        self.post_calls.append({"url": url, "kwargs": kwargs})
+        for prefix, result in self.post_dispatch.items():
+            if url.startswith(prefix):
+                return result
+        return self.post_result
+
+
+# ---------------------------------------------------------------------------
+# Webservice transport
+# ---------------------------------------------------------------------------
+
+
+def test_webservice_call_returns_parsed_response_on_success():
+    """A successful webservice call returns the parsed JSON payload."""
+    session = StubSession(post_result=StubResponse(json_data=[{"id": 2}, {"id": 1}]))
+
+    result = webservice_transport.call(
+        session, BASE_URL, "core_course_get_courses", FAKE_TOKEN
+    )
+
+    assert result == [{"id": 2}, {"id": 1}]
+
+
+def test_webservice_call_raises_transport_unavailable_on_invalid_token():
+    """An 'Invalid token' Moodle response signals a transport fallback."""
+    session = StubSession(
+        post_result=StubResponse(
+            json_data={
+                "exception": "moodle_exception",
+                "errorcode": "invalidtoken",
+                "message": "Invalid token - token not found",
+            }
+        )
+    )
+
+    with pytest.raises(TransportUnavailableError):
+        webservice_transport.call(
+            session, BASE_URL, "core_course_get_courses", FAKE_TOKEN
+        )
+
+
+def test_webservice_call_raises_transport_error_on_other_moodle_exception():
+    """A non-token Moodle exception raises a plain TransportError."""
+    session = StubSession(
+        post_result=StubResponse(
+            json_data={
+                "exception": "required_capability_exception",
+                "errorcode": "nopermissions",
+                "message": "Access control exception",
+            }
+        )
+    )
+
+    with pytest.raises(TransportError) as excinfo:
+        webservice_transport.call(
+            session, BASE_URL, "core_course_get_courses", FAKE_TOKEN
+        )
+
+    assert not isinstance(excinfo.value, TransportUnavailableError)
+    assert "Access control exception" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# AJAX transport
+# ---------------------------------------------------------------------------
+
+
+def test_ajax_call_returns_unwrapped_data_on_success():
+    """A successful AJAX call returns the unwrapped data payload."""
+    session = StubSession(
+        get_result=StubResponse(text="<html></html>"),
+        post_result=StubResponse(
+            json_data=[{"error": False, "data": [{"id": 1}, {"id": 2}]}]
+        ),
+    )
+
+    result = ajax_transport.call(
+        session, BASE_URL, "core_course_get_courses", FAKE_SESSKEY
+    )
+
+    assert result == [{"id": 1}, {"id": 2}]
+    # The pre-flight session refresh must happen before the AJAX call.
+    assert session.get_calls
+    assert session.get_calls[0]["url"] == f"{BASE_URL}/my/"
+
+
+def test_ajax_call_without_sesskey_raises_transport_unavailable_without_http():
+    """Without a sesskey the AJAX transport fails fast, with no HTTP call."""
+    session = StubSession()
+
+    with pytest.raises(TransportUnavailableError):
+        ajax_transport.call(session, BASE_URL, "core_course_get_courses", None)
+
+    assert session.get_calls == []
+    assert session.post_calls == []
+
+
+# ---------------------------------------------------------------------------
+# list_courses(): migrated to use the transport strategies
+# ---------------------------------------------------------------------------
+
+
+def test_list_courses_uses_webservice_when_token_succeeds():
+    """list_courses() returns sorted courses via webservice, without AJAX."""
+    session = StubSession(post_result=StubResponse(json_data=[{"id": 2}, {"id": 1}]))
+
+    result = list_courses(session, BASE_URL, token=FAKE_TOKEN)
+
+    assert result == [{"id": 1}, {"id": 2}]
+    assert all("lib/ajax/service.php" not in call["url"] for call in session.post_calls)
+
+
+def test_list_courses_falls_back_to_ajax_on_invalid_token():
+    """list_courses() falls back to AJAX when the webservice token is invalid."""
+    session = StubSession(
+        get_result=StubResponse(text="<html></html>"),
+        post_dispatch={
+            f"{BASE_URL}/webservice/rest/server.php": StubResponse(
+                json_data={
+                    "exception": "moodle_exception",
+                    "errorcode": "invalidtoken",
+                    "message": "Invalid token - token not found",
+                }
+            ),
+            f"{BASE_URL}/lib/ajax/service.php": StubResponse(
+                json_data=[{"error": False, "data": [{"id": 2}, {"id": 1}]}]
+            ),
+        },
+    )
+
+    result = list_courses(session, BASE_URL, token="bad-token", sesskey=FAKE_SESSKEY)
+
+    assert result == [{"id": 1}, {"id": 2}]
+
+
+def test_list_courses_raises_when_neither_transport_usable():
+    """list_courses() raises a clear error with no token and no sesskey."""
+    session = StubSession()
+
+    with pytest.raises(MoodleCourseError) as excinfo:
+        list_courses(session, BASE_URL)
+
+    assert "token or sesskey" in str(excinfo.value)
+    assert session.post_calls == []
+    assert session.get_calls == []


### PR DESCRIPTION
## Summary
Introduces an explicit `src/py_moodle/transport/` package (`webservice.py`, `ajax.py`, `html.py`) that names and formalizes the three transports `py-moodle` uses to talk to Moodle, built on top of the centralized `http.py` client from #54. `list_courses()` in `src/py_moodle/course.py` is migrated as a single proof-of-concept flow: its webservice-then-AJAX fallback logic now delegates to the new transport modules instead of inlining both request/response shapes in the function body. No other call site is migrated in this change.

## Linked issue
Closes #40

**Stacked on #54** ("Centralize HTTP requests, timeouts, retries, and error handling"): this branch is created on top of `issue-39-centralize-http` and its `transport/webservice.py`/`transport/ajax.py` modules call into `py_moodle.http`'s `request_webservice`/`request_ajax`/`request_html_get` helpers rather than `requests.Session.get`/`.post` directly. This PR should be reviewed/merged after #54, not independently — its diff below is additive on top of #54's changes.

## Specification
- `transport/__init__.py`: `TransportError` (base) and `TransportUnavailableError` (raised when a transport cannot be used for this call, signaling the caller to try the next transport in the fallback chain).
- `transport/webservice.py`: `call(session, base_url, wsfunction, token, params=None)` — calls the REST webservice via `http.request_webservice`, raises `TransportUnavailableError` on an `"Invalid token"`-style Moodle response, `TransportError` for any other failure.
- `transport/ajax.py`: `call(session, base_url, methodname, sesskey, args=None)` — calls the internal AJAX endpoint via `http.request_ajax`, preserving the pre-flight `session.get(f"{base_url}/my/")` refresh; raises `TransportUnavailableError` when no `sesskey` is supplied (without making any HTTP call), `TransportError` for any other failure.
- `transport/html.py`: interface-only placeholder documenting a future HTML-scraping/form-submission transport; `call(...)` always raises `NotImplementedError`.
- `course.py`'s `list_courses()`: same public signature/return type/sort order/raised-exception type as before; internally tries `webservice.call()` first, falls through to `ajax.call()` on `TransportUnavailableError`, and translates any `TransportError` into `MoodleCourseError` so the new transport exception types never leak past `course.py`.

## Implementation details
- `src/py_moodle/transport/__init__.py` (new): `TransportError`, `TransportUnavailableError`.
- `src/py_moodle/transport/webservice.py` (new): `call()` wraps `http.request_webservice()`, catching `MoodleWebserviceError` and inspecting the message for an `"invalid token"` substring (case-insensitive) to decide `TransportUnavailableError` vs `TransportError`; other `MoodleHttpError`s become `TransportError`.
- `src/py_moodle/transport/ajax.py` (new): `call()` fails fast with `TransportUnavailableError` when `sesskey` is falsy (no HTTP call made), otherwise performs the `/my/` refresh GET, then POSTs the `[{"index": 0, "methodname": ..., "args": ...}]` envelope via `http.request_ajax()` and returns `result[0]["data"]`; any `MoodleHttpError` from either call becomes `TransportError`.
- `src/py_moodle/transport/html.py` (new): interface-only `call()` signature, raises `NotImplementedError`.
- `src/py_moodle/course.py`: `list_courses()` rewritten to call `webservice_transport.call()` then `ajax_transport.call()` instead of `http.request_webservice()`/`request_ajax()`/`request_html_get()` directly; removed now-unused `request_ajax`/`request_html_get`/`request_webservice` imports (kept `MoodleHttpError`/`request_form_post`, still used by `create_course()`). No other function in `course.py` was touched.
- `docs/api/transport.md` (new) + `mkdocs.yml` nav entry: mkdocstrings page for `py_moodle.transport`, `.webservice`, `.ajax`, `.html`.
- `docs/development.md`: new "Transport Strategies" subsection describing the new package and noting remaining call sites are follow-up work.

## Test plan
- [x] Added failing tests first.
- [x] Confirmed the tests failed before implementation.
- [x] Implemented the feature/refactor.
- [x] Confirmed the focused tests pass.
- [x] Confirmed the full "pytest tests/unit" suite passes.

Commands run:
```bash
# Red: transport package does not exist yet
.venv/bin/pytest tests/unit/test_transport.py -q
# -> ImportError: cannot import name 'TransportError' from 'py_moodle.transport'

# Green: after implementing transport/__init__.py, webservice.py, ajax.py, html.py
# and migrating list_courses()
.venv/bin/pytest tests/unit/test_transport.py tests/unit/test_error_messages.py -q
# -> 13 passed

# Full regression
.venv/bin/pytest tests/unit -q
# -> 63 passed

# Lint
.venv/bin/black --check src tests
.venv/bin/isort --check-only src tests
.venv/bin/flake8
```

## Backward compatibility
- `list_courses(session, base_url, *, token=None, sesskey=None) -> List[Dict[str, Any]]` keeps its exact signature, return type, `id`-ascending sort order, and `MoodleCourseError` as the only exception type visible to callers.
- No CLI command, option, or output format changes; `src/py_moodle/cli/` untouched.
- `src/py_moodle/transport/` is purely additive; nothing else imports from it yet except the one migrated `list_courses()` call site.
- `get_course_state`/`get_course()`, and the AJAX calls in `section.py`, `module.py`, `draftfile.py` are completely unchanged.
- Not independently mergeable to `main`: depends on #54 merging first (or being rebased together as a stack).

## Documentation
- Added `docs/api/transport.md` (mkdocstrings-generated) and its `mkdocs.yml` nav entry under API Reference > Core.
- Added a "Transport Strategies" subsection to `docs/development.md` explaining the new package and calling out remaining migrations as follow-up work.
- `docs/cli.md` unchanged (no CLI-facing change in this PR).
- All new public functions/classes have Google-style docstrings for mkdocstrings.

## Risk assessment
- Low risk: purely additive package plus a single internal refactor of `list_courses()` with unchanged public behavior, backed by unit tests covering the happy path, invalid-token fallback, and the "neither transport usable" error path.
- One subtle behavior change worth flagging for review: previously `list_courses()` caught a bare `except Exception` around the webservice attempt (silently falling back to AJAX on *any* error, including e.g. malformed response shapes). It now only falls back on `TransportUnavailableError` (invalid/expired token) and raises `MoodleCourseError` immediately for any other `TransportError` — this matches the issue's SDD specification exactly and makes non-token webservice failures surface immediately instead of being masked by a silent AJAX retry.

## Manual verification
```python
from unittest.mock import MagicMock
from py_moodle.course import list_courses
from py_moodle.transport import webservice as webservice_transport

session = MagicMock()
session.post.return_value.status_code = 200
session.post.return_value.json.return_value = [{"id": 2}, {"id": 1}]

result = list_courses(session, "https://moodle.example.test", token="tok")
print(result)
# -> [{'id': 1}, {'id': 2}]  (webservice transport used, sorted by id)
```
See `tests/unit/test_transport.py` for the full set of mocked scenarios (webservice success, invalid-token fallback to AJAX, AJAX success with the `/my/` pre-flight refresh, AJAX unavailable without a sesskey, and the combined "neither transport usable" error).

## Notes for reviewers
- This PR intentionally migrates only `list_courses()`. `get_course_state()`/`get_course()` in `course.py`, and the AJAX calls in `section.py`, `module.py`, and `draftfile.py` are explicitly left as-is and should be tracked as separate follow-up issues, per the issue's "Out of Scope" section.
- `transport/html.py` is interface-only in this PR (raises `NotImplementedError`); no real HTML-scraping/form-submission logic is wired up, per scope.
- Please review this stacked on top of #54 — the diff here assumes `py_moodle.http` (from #54) already exists and is stable.