### PR TITLE
Migrate documentation site from MkDocs to Zensical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,25 @@ jobs:
       - name: Lint
         run: make lint
 
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Build documentation site
+        run: make docs
+
   unit:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,13 +17,15 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
 
       - name: Install Python deps
         run: |
           pip install -r requirements.txt
           pip install -e .
 
-      - name: Build MkDocs site
+      - name: Build documentation site
         run: make docs
 
       - name: Deploy to GitHub Pages

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint:
 
 docs:
 	python -m typer py_moodle.cli.app utils docs --output docs/cli.md --name py-moodle
-	mkdocs build --strict
+	zensical build
 
 test-unit:
 	pytest tests/unit
@@ -69,7 +69,7 @@ help:
 	@echo "  lint               - Lint code with black, isort, and flake8"
 	@echo ""
 	@echo "Documentation:"
-	@echo "  docs               - Build documentation with mkdocs"
+	@echo "  docs               - Build documentation with Zensical"
 	@echo ""
 	@echo "Testing:"
 	@echo "  test-unit          - Run fast smoke tests that do not require Moodle"

--- a/README.md
+++ b/README.md
@@ -281,14 +281,14 @@ make docs     # build the MkDocs site
 
 ## Documentation
 
-Documentation is generated with [MkDocs](https://www.mkdocs.org/) using the Read the Docs theme and published automatically to the `gh-pages` branch.
+Documentation is generated with [Zensical](https://zensical.org/) using the Material theme and published automatically to the `gh-pages` branch.
 Every push to `main` builds the API reference and CLI guide from the source code and makes it available via GitHub Pages.
 
-To build the documentation locally:
+To build the documentation locally (requires Python 3.10+):
 
 ```bash
-pip install mkdocs 'mkdocstrings[python]'
-mkdocs build --strict
+pip install zensical 'mkdocstrings[python]'
+zensical build
 ```
 
 The rendered site will be available under the `site/` directory.

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,8 +25,8 @@ pip install -e .
 # Core development tools
 pip install black isort flake8 pytest
 
-# Documentation tools
-pip install mkdocs mkdocs-material mkdocstrings[python]
+# Documentation tools (Zensical requires Python 3.10+)
+pip install zensical mkdocstrings[python]
 ```
 
 ## Code Style and Standards
@@ -264,16 +264,21 @@ might log a secret-bearing value:
 
 ### Building Documentation
 
+The site is built with [Zensical](https://zensical.org/), the actively-maintained
+successor to MkDocs from the Material for MkDocs team. It reads the existing
+`mkdocs.yml` directly, so no separate config file is needed. Zensical requires
+Python 3.10+.
+
 ```bash
 # Build documentation
 make docs
 
 # Serve documentation locally
-mkdocs serve
-
-# Deploy to GitHub Pages
-mkdocs gh-deploy
+zensical serve
 ```
+
+Deployment to GitHub Pages happens automatically via
+`.github/workflows/docs.yml` on every push to `main`.
 
 ### Adding API Documentation
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,7 +1,22 @@
-:root {
-  --md-primary-fg-color: #1976d2;
-  --md-primary-fg-color--light: #42a5f5;
-  --md-primary-fg-color--dark: #1565c0;
+/*
+ * Moodle brand orange (#f98012), per Moodle's Global Brand Guidelines.
+ * Moodle's own guidelines note that white-on-orange and orange-on-white
+ * both fail WCAG AA contrast, so header/nav text uses Moodle Black
+ * (#282828) instead of the Material default white, matching how Moodle's
+ * own brand materials pair orange buttons with dark text.
+ */
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color: #f98012;
+  --md-primary-fg-color--light: #ffa64d;
+  --md-primary-fg-color--dark: #c96700;
+  --md-primary-bg-color: #282828;
+  --md-primary-bg-color--light: #282828;
+}
+
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: #f98012;
+  --md-accent-fg-color--transparent: #f980121a;
+  --md-accent-bg-color: #282828;
 }
 
 .md-typeset .admonition.warning {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,14 +11,14 @@ theme:
   favicon: images/favicon.png
   palette:
   - scheme: default
-    primary: blue
-    accent: blue
+    primary: custom
+    accent: custom
     toggle:
       icon: material/brightness-7
       name: Switch to dark mode
   - scheme: slate
-    primary: blue
-    accent: blue
+    primary: custom
+    accent: custom
     toggle:
       icon: material/brightness-4
       name: Switch to light mode
@@ -87,6 +87,8 @@ plugins:
           group_by_category: true
           show_category_heading: true
           show_if_no_docstring: true
+extra_css:
+- stylesheets/extra.css
 extra:
   social:
   - icon: fontawesome/brands/github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,9 @@ dev = [
     "black",
     "mypy",
     "isort",
-    "mkdocs",
     "mkdocstrings[python]",
     "pymdown-extensions",
-    "mkdocs-material",
-    "mkdocs-autorefs",
-    "mkdocs-git-revision-date-localized-plugin",
-    "mkdocs-minify-plugin"
+    "zensical; python_version >= '3.10'",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,11 +18,6 @@ flake8-docstrings
 black
 mypy
 isort
-mkdocs
 mkdocstrings[python]
 pymdown-extensions
-mkdocs-material
-mkdocs-autorefs
-mkdocs-git-revision-date-localized-plugin
-mkdocs-minify-plugin
-pymdown-extensions
+zensical; python_version >= "3.10"


### PR DESCRIPTION
## Summary
Replaces the `mkdocs`/`mkdocs-material` documentation toolchain with [Zensical](https://zensical.org/), the actively-maintained successor built by the same team, and re-brands the docs site header with Moodle's official orange (`#f98012`).

## Linked issue
Closes #59

## Specification
See #59 for the full SDD. In short: Zensical reads the existing `mkdocs.yml` natively, so this is a toolchain swap plus a small color/CSS change, not a content rewrite.

## Implementation details
- `pyproject.toml` / `requirements.txt`: replaced `mkdocs`, `mkdocs-material`, `mkdocs-autorefs` with `zensical` (marked `python_version >= '3.10'`, since Zensical 0.0.3+ requires it — this repo's own Python 3.9 CI/dev-install leg simply skips it, no breakage). Dropped `mkdocs-git-revision-date-localized-plugin` and `mkdocs-minify-plugin`, which were listed as dev dependencies but never actually referenced in `mkdocs.yml`'s `plugins:` list.
- `Makefile`: `docs` target now runs `zensical build` instead of `mkdocs build --strict` (Zensical doesn't document a `--strict` equivalent).
- `.github/workflows/docs.yml`: pinned Python to 3.12 (Zensical's Python 3.10+ requirement).
- `.github/workflows/ci.yml`: **added a new `docs` job** that builds the site on every push/PR. This didn't exist before — `docs.yml` only runs on push to `main` and deploys directly to `gh-pages`, so there was no way to catch a broken build before it went live. This new job is also how this PR gets real verification (see Risk assessment).
- `mkdocs.yml`: switched `theme.palette.primary`/`accent` from `blue` to `custom`, and wired in `extra_css: [stylesheets/extra.css]` (this file already existed with an unrelated blue override but was never referenced anywhere — dead CSS).
- `docs/stylesheets/extra.css`: set `--md-primary-fg-color`/`--md-accent-fg-color` to Moodle's official brand orange `#f98012` (per Moodle's 2025 Global Brand Guidelines). Text color uses Moodle Black (`#282828`), not the Material default white — Moodle's own guidelines explicitly note that white-on-orange (and orange-on-white) both fail WCAG AA contrast, and their own brand materials pair orange buttons with dark text.
- `docs/development.md` and `README.md`: updated build instructions.

## Test plan
- [x] Verified the *updated* `mkdocs.yml` still builds cleanly with the current `mkdocs`/`mkdocs-material` toolchain (a config-validity proxy, since Zensical reads the identical file format).
- [x] Confirmed `data-md-color-primary="custom"` is rendered on every page and matches the new CSS selector — the color wiring is structurally correct.
- [x] `pytest tests/unit` (197 tests) and `make lint` — untouched, still green (zero Python source changes).

Commands run:
```bash
PYTHONPATH=src mkdocs build --strict   # sanity-checks the new mkdocs.yml
pytest tests/unit -q
black --check src tests && isort --check-only src tests && flake8
```

- [ ] **Could not verify an actual Zensical build locally** — the sandboxed environment used to prepare this PR only has access to zensical 0.0.0–0.0.2 (empty placeholder releases predating real mkdocstrings support, which landed in 0.0.11+), not the current release. The new `docs` job in `ci.yml` (this PR) runs on GitHub's runners with full package-index access and is the actual verification — **please check that job's result on this PR before merging**, and watch `.github/workflows/docs.yml`'s run immediately after merge (it deploys straight to `gh-pages`).

## Backward compatibility
Fully backward compatible for end users: content, URL structure, and navigation are unchanged (Zensical's own compatibility docs state "files stay where they are; URLs and anchors remain identical"). Only the build tool changes for contributors/CI. No PyPI package or CLI/library behavior changes.

## Risk assessment
- **Pre-1.0 tool**: Zensical is at v0.0.x. Its own docs describe mkdocstrings support as "preliminary" (some features, e.g. backlinks, not yet supported). If the `docs` CI job reveals real incompatibilities with any `docs/api/*.md` page, that's the signal to hold this PR rather than merge.
- **Python 3.10+ requirement**: handled via a conditional dependency marker, matching this repo's existing pattern for `setuptools`.
- **No PR-time deploy verification existed before this PR** for the docs pipeline; the new `ci.yml` `docs` job closes that gap going forward, independent of Zensical.

## Manual verification
```bash
pip install -e ".[dev]"   # Python 3.10+
make docs                  # regenerates docs/cli.md, then zensical build
zensical serve             # preview locally, confirm the header is Moodle orange
```

## Notes for reviewers
Please specifically check the `docs` job's output on this PR (real Zensical, real internet access) before merging — that's the part I could not verify locally, flagged explicitly above rather than silently assumed to work.