### PR TITLE
Fall back to AJAX on a Moodle course-context validation error

### DIFF
--- a/src/py_moodle/transport/webservice.py
+++ b/src/py_moodle/transport/webservice.py
@@ -14,10 +14,22 @@ import requests
 from ..http import MoodleHttpError, MoodleWebserviceError, request_webservice
 from . import TransportError, TransportUnavailableError
 
-#: Substring (case-insensitive) that identifies an invalid/expired token
-#: Moodle exception, distinguishing "try another transport" from a genuine
-#: webservice-level failure.
-_INVALID_TOKEN_MARKER = "invalid token"
+#: Substrings (case-insensitive) identifying a Moodle webservice failure
+#: that means "this call path isn't usable right now, try another
+#: transport" rather than a genuine webservice-level failure worth
+#: surfacing immediately:
+#:   - an invalid/expired token;
+#:   - a webservice-side context-validation failure (observed in practice
+#:     as "You cannot execute functions in the course context (course
+#:     id:N). ... Context does not exist"), e.g. when the target course's
+#:     context is momentarily stale relative to the calling user's cached
+#:     session state. The AJAX transport re-derives context from the
+#:     current page/session instead of a cached webservice-side lookup,
+#:     so it is not subject to the same failure.
+_TRANSPORT_UNAVAILABLE_MARKERS = (
+    "invalid token",
+    "cannot execute functions in the course context",
+)
 
 
 def call(
@@ -41,15 +53,17 @@ def call(
 
     Raises:
         TransportUnavailableError: If Moodle reports an invalid/expired
-            token, indicating the caller should fall back to another
-            transport.
+            token, or a context-validation failure, indicating the caller
+            should fall back to another transport (see
+            :data:`_TRANSPORT_UNAVAILABLE_MARKERS`).
         TransportError: If the call fails for any other reason (network
-            error, non-token Moodle exception, invalid JSON).
+            error, non-token/context Moodle exception, invalid JSON).
     """
     try:
         return request_webservice(session, base_url, wsfunction, params, token=token)
     except MoodleWebserviceError as exc:
-        if _INVALID_TOKEN_MARKER in str(exc).lower():
+        message = str(exc).lower()
+        if any(marker in message for marker in _TRANSPORT_UNAVAILABLE_MARKERS):
             raise TransportUnavailableError(str(exc)) from exc
         raise TransportError(str(exc)) from exc
     except MoodleHttpError as exc:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -83,6 +83,37 @@ def test_webservice_call_raises_transport_unavailable_on_invalid_token():
         )
 
 
+def test_webservice_call_raises_transport_unavailable_on_context_error():
+    """A 'cannot execute functions in the course context' error signals fallback.
+
+    Regression test for a Moodle webservice quirk observed in CI: a call to
+    a generic, non-course-scoped function like ``core_course_get_courses``
+    can still fail with a stale/invalid course-context validation error
+    unrelated to the token itself. This must be treated the same as an
+    invalid token -- fall back to another transport -- rather than
+    surfacing immediately, since the AJAX transport re-derives context from
+    the current session instead of a cached webservice-side lookup.
+    """
+    session = StubSession(
+        post_result=StubResponse(
+            json_data={
+                "exception": "invalid_parameter_exception",
+                "errorcode": "invalidparameter",
+                "message": (
+                    "You cannot execute functions in the course context "
+                    "(course id:8). The context error message was: Invalid "
+                    "parameter value detected (Context does not exist)"
+                ),
+            }
+        )
+    )
+
+    with pytest.raises(TransportUnavailableError):
+        webservice_transport.call(
+            session, BASE_URL, "core_course_get_courses", FAKE_TOKEN
+        )
+
+
 def test_webservice_call_raises_transport_error_on_other_moodle_exception():
     """A non-token Moodle exception raises a plain TransportError."""
     session = StubSession(
@@ -173,6 +204,37 @@ def test_list_courses_falls_back_to_ajax_on_invalid_token():
     )
 
     result = list_courses(session, BASE_URL, token="bad-token", sesskey=FAKE_SESSKEY)
+
+    assert result == [{"id": 1}, {"id": 2}]
+
+
+def test_list_courses_falls_back_to_ajax_on_context_error():
+    """list_courses() falls back to AJAX on a course-context validation error.
+
+    Same regression as test_webservice_call_raises_transport_unavailable_on_context_error,
+    exercised through the public list_courses() entry point.
+    """
+    session = StubSession(
+        get_result=StubResponse(text="<html></html>"),
+        post_dispatch={
+            f"{BASE_URL}/webservice/rest/server.php": StubResponse(
+                json_data={
+                    "exception": "invalid_parameter_exception",
+                    "errorcode": "invalidparameter",
+                    "message": (
+                        "You cannot execute functions in the course context "
+                        "(course id:8). The context error message was: Invalid "
+                        "parameter value detected (Context does not exist)"
+                    ),
+                }
+            ),
+            f"{BASE_URL}/lib/ajax/service.php": StubResponse(
+                json_data=[{"error": False, "data": [{"id": 2}, {"id": 1}]}]
+            ),
+        },
+    )
+
+    result = list_courses(session, BASE_URL, token=FAKE_TOKEN, sesskey=FAKE_SESSKEY)
 
     assert result == [{"id": 1}, {"id": 2}]
 


### PR DESCRIPTION
## Summary
`list_courses()`'s webservice-to-AJAX fallback only triggered on an invalid/expired token. Broadens it to also cover a real, CI-observed Moodle course-context validation quirk, so callers transparently recover via AJAX instead of erroring out.

## Linked issue
Closes #63

## Specification
See #63 for the full write-up and CI evidence (two separate failed runs, three different tests affected, all on PR #62).

## Implementation details
- `src/py_moodle/transport/webservice.py`: renamed the single `_INVALID_TOKEN_MARKER` to a `_TRANSPORT_UNAVAILABLE_MARKERS` tuple, adding `"cannot execute functions in the course context"` (the stable, generic part of the Moodle message — the course id and exact sub-message vary) alongside the existing invalid-token marker. Both now raise `TransportUnavailableError` (fall back to AJAX) instead of `TransportError` (raise immediately).
- `tests/unit/test_transport.py`: two new regression tests reproducing the exact error message seen in CI, at both the `webservice_transport.call()` level and the public `list_courses()` level.

## Test plan
- [x] Added the failing tests first.
- [x] Confirmed they failed against the pre-fix code (via `git stash` on just the source file) — reproduced the exact CI traceback shape.
- [x] Implemented the fix (broadened marker list).
- [x] Confirmed the two new tests pass, plus all 10 tests in `test_transport.py`.
- [x] Confirmed the full `pytest tests/unit` suite (199 tests) and `make lint` are still green.

Commands run:
```bash
pytest tests/unit/test_transport.py -k context_error -q   # red, via git stash on webservice.py
git stash pop
pytest tests/unit/test_transport.py -q                     # green, all 10 pass
pytest tests/unit -q                                        # 199 passed
black --check src tests && isort --check-only src tests && flake8
```

## Backward compatibility
Fully backward compatible. Only broadens which errors trigger the *existing* AJAX fallback path (already exercised by `test_list_courses_falls_back_to_ajax_on_invalid_token`); does not change `list_courses()`'s signature, return shape, or any other function's behavior. Genuine, non-context, non-token `TransportError`s (e.g. permissions denials) still raise immediately, unchanged, per the existing `test_webservice_call_raises_transport_error_on_other_moodle_exception` test.

## Risk assessment
The marker-string approach matches this file's existing, already-reviewed convention (`_INVALID_TOKEN_MARKER`) rather than introducing a new classification mechanism. As with any English-substring match on a Moodle error message, it's not immune to locale/wording drift in a future Moodle release — same caveat that already applied to the invalid-token marker before this PR.

## Manual verification
Can't reproduce this specific race against a live Moodle instance from this environment on demand (it's timing-dependent), but the CI evidence in #63 is the real-world reproduction. The regression test in `test_transport.py` reproduces the exact error message deterministically without needing live Moodle or a race.

## Notes for reviewers
This was discovered *while* verifying PR #62 (test de-flaking), not something #62 introduced — #62 is unrelated test-fixture code; this is a production `src/py_moodle/transport/webservice.py` fix. Kept as its own focused PR rather than folded into #62.