### PR TITLE
CI: make integration containers ephemeral (drop volumes) + log container output on boot timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ upd: check-docker ensure-env
 	  sleep 5; \
 	done; \
 	if [ $$ready -ne 1 ]; then \
-	  echo "Moodle did not become ready in time."; \
+	  echo "Moodle did not become ready in time. Recent container logs:"; \
+	  docker compose logs --tail=80 moodle || true; \
 	  exit 1; \
 	fi
 	@echo "Grace period: the login page can respond before Moodle's own"; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,11 +67,8 @@ services:
 
     ports:
       - 80:8080
-    volumes:
-      - moodledata:/var/www/moodledata
     depends_on:
       - postgres
 
 volumes:
   postgres: null
-  moodledata: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,11 +69,9 @@ services:
       - 80:8080
     volumes:
       - moodledata:/var/www/moodledata
-      - moodlehtml:/var/www/html
     depends_on:
       - postgres
 
 volumes:
   postgres: null
   moodledata: null
-  moodlehtml: null


### PR DESCRIPTION
## Summary
Two small CI-infrastructure improvements to the Docker-backed integration setup. **Note:** this does *not* by itself fix the Moodle 5.1 boot failure — that is a moosh-vs-Moodle-5.1 bug in the `erseco/alpine-moodle` image, fixed separately in erseco/alpine-moodle#149. What this PR adds is the on-timeout container-log dump that made that root cause diagnosable, plus ephemeral-CI cleanup.

## Linked issue
Closes #72

## Changes
- **`docker-compose.yml`: drop the `moodlehtml` and `moodledata` named volumes.** A CI integration container is created, tested, and destroyed in a single run (no restarts), so persisting the code tree or data directory across restarts provides no benefit; the image is self-contained and manages both paths on its own writable layer within the run. This also removes the slow first-boot image→volume copy of the (larger, on 5.1) `/var/www/html` tree. A single CI run's correctness is unchanged. Local dev keeps working (code from image; data no longer persisted across `docker compose down`, which is fine for a disposable test instance).
- **`Makefile` (`upd`): dump the last 80 lines of the `moodle` container log on readiness timeout**, so a boot failure is diagnosable from the CI log instead of an opaque "did not become ready". This is exactly what surfaced the moosh/5.1 root cause.

## Root cause of the 5.1 timeout (for context; fixed in the image PR)
The `erseco/alpine-moodle` 5.1 image never starts nginx within the window: Moodle 5.1 moved `version.php` into `public/`, so `moosh` (pointed at `/var/www/html`) can't bootstrap and every moosh command in `POST_CONFIGURE_COMMANDS` fails; the non-zero exit crash-loops the container. Fixed in erseco/alpine-moodle#149.

## Test plan
Infra-only (docker-compose + Makefile); no unit surface. Verified: `docker-compose.yml` is valid YAML with `volumes: [postgres]` only and no stray `moodledata`/`moodlehtml` refs; `make -n upd` parses. The 4.5.5 and 5.0.1 legs still boot and run the suite (confirmed on earlier runs of this branch: 48–49 tests ran; remaining errors are the separately-tracked login race and the #63 context bug).

## Backwards compatibility
No application/library/CLI change. Local dev unaffected except that a disposable test instance no longer persists data across `docker compose down`.