### PR TITLE
Harden integration tests against the post-boot Moodle login race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import time
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -163,6 +164,47 @@ def pytest_collection_modifyitems(config, items):
         item.add_marker(pytest.mark.integration)
         if not run_integration:
             item.add_marker(skip_integration)
+
+
+#: Retry budget for the per-session login warmup (attempts x delay seconds).
+_LOGIN_WARMUP_ATTEMPTS = 6
+_LOGIN_WARMUP_DELAY_SECONDS = 5
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_up_moodle_login(request):
+    """Warm up Moodle login once per session to absorb the post-boot race.
+
+    Immediately after a freshly-started Moodle container begins serving its
+    login page, the first login attempt intermittently fails with
+    "invalid username or password" while Moodle finishes initializing
+    (caches, sessions). This surfaced as flaky ``LoginError`` failures in
+    the integration suite, on whichever test a ``pytest-xdist`` worker
+    happened to run first. Perform a retrying warmup login once per session
+    (i.e. once per xdist worker) so the per-test logins that follow are
+    reliable; a successful warmup means the Moodle server is warm for every
+    subsequent (new-session) login.
+
+    No-op unless integration tests are actually running.
+    """
+    if not request.config.getoption("--integration"):
+        return
+    target = request.config.moodle_target
+    from py_moodle.auth import LoginError, login
+
+    last_error = None
+    for attempt in range(1, _LOGIN_WARMUP_ATTEMPTS + 1):
+        try:
+            login(url=target.url, username=target.username, password=target.password)
+            return
+        except LoginError as error:
+            last_error = error
+            if attempt < _LOGIN_WARMUP_ATTEMPTS:
+                time.sleep(_LOGIN_WARMUP_DELAY_SECONDS)
+    pytest.exit(
+        f"Moodle at '{target.name}' never accepted login after "
+        f"{_LOGIN_WARMUP_ATTEMPTS} warmup attempts: {last_error}"
+    )
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary
Eliminates the recurring integration-test flake where fixture setup fails with `Moodle login failed: invalid username or password`. Adds a session-scoped, autouse **login warmup** (retry) fixture so a freshly-booted Moodle is warm before any test logs in. Integration-harness only; no library/CLI change.

## Problem
Right after a fresh Moodle container starts serving `/login/index.php`, the *first* login attempt intermittently fails with "invalid username or password" while Moodle finishes initializing (caches/sessions); a moment later the same credentials work — which is exactly why every occurrence went green on rerun. Under `pytest-xdist -n auto` this hit whichever test a worker ran first (observed on `test_create_and_delete_course`, `test_add_assign`, `test_list_courses`, …), making the whole suite flaky and forcing repeated CI reruns.

## Fix
A `scope="session", autouse=True` fixture (`_warm_up_moodle_login`) in `tests/conftest.py` that, **only when `--integration` is active**, performs a retrying warmup login (up to 6 attempts, 5s apart) once per session — i.e. once per xdist worker — before tests run. Once the warmup login succeeds the Moodle server is warm, so every subsequent per-test (new-session) login is reliable. If login never succeeds within the budget it `pytest.exit`s with a clear message (a genuinely-down Moodle still fails fast-ish, not silently).

## Test plan
- `pytest tests/unit` — green; the warmup fixture is a no-op without `--integration`, so unit runs are unaffected.
- `make lint` (black/isort/flake8) — clean.
- Real validation is this PR's integration matrix (4.5.5 / 5.0.1 / 5.1.5): the login-race errors should stop recurring. If any leg still flakes on an *unrelated* race (e.g. a parallel course-state collision), that is a separate, pre-existing issue.

## Backwards compatibility
No change to any library or CLI behavior; only the integration test harness. Unit tests, and any environment without `--integration`, are unaffected.

## Notes for reviewers
This is the counterpart to #62 (which serialized course *creation* across workers) and #73 (ephemeral CI containers + boot diagnostics): together they target the main sources of integration flakiness. The warmup absorbs the *login* race specifically. Retry budget (6×5s) is generous but only spends time when the race is actually occurring — a first-try success is instant.