### PR TITLE
Ship py.typed (PEP 561)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -61,6 +61,11 @@ flake8 src/ tests/
 - **Type hints**: Encouraged for new code
 - **Line length**: 88 characters (Black default)
 
+The package is PEP 561 typed: it ships a `py.typed` marker
+(`src/py_moodle/py.typed`, packaged via `[tool.setuptools.package-data]` in
+`pyproject.toml`), so type checkers such as mypy and pyright pick up the inline
+annotations that `py_moodle` already exposes for downstream consumers.
+
 Example function with proper docstring:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ py-moodle = "py_moodle.cli:app"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+py_moodle = ["py.typed"]
+
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"
 

--- a/tests/unit/test_py_typed.py
+++ b/tests/unit/test_py_typed.py
@@ -1,0 +1,18 @@
+"""Tests that the package ships a PEP 561 ``py.typed`` marker."""
+
+import pathlib
+
+import py_moodle
+
+
+def test_py_typed_marker_is_present():
+    """The ``py_moodle`` package should include a ``py.typed`` marker.
+
+    Per PEP 561, the presence of ``py.typed`` inside the installed package
+    tells type checkers (mypy/pyright) that the package ships inline type
+    annotations and should be treated as typed by downstream consumers.
+    """
+    package_dir = pathlib.Path(py_moodle.__file__).parent
+    marker = package_dir / "py.typed"
+
+    assert marker.is_file()


### PR DESCRIPTION
## Summary
Ship an empty `src/py_moodle/py.typed` marker and configure setuptools to include it in the wheel/sdist, so PEP 561 consumers (mypy, pyright) treat `py_moodle` as typed and pick up the inline annotations the package already exposes. Additive only; no runtime behavior changes and no new annotations.

## Linked issue
Closes #78

## Specification (SDD)
Implements the issue's SDD scope (sections 1-9), roadmap Subtask 14 (part of #65, wave 3):
- Section 3 (Desired behavior): ship an empty `py.typed` marker and configure setuptools to package it.
- Section 5 (Public contract): the distributed `py_moodle` package includes `py.typed`; type checkers pick up existing annotations.
- Section 6 (Test plan): a unit test asserts the marker is present inside the package.
- Section 7 (Documentation impact): a short PEP 561 note in `docs/development.md`.
- Section 4 (Non-goals) respected: no new annotations, no `--strict` mypy work.

## TDD evidence
Red — wrote `tests/unit/test_py_typed.py` first and ran it before implementing:

```
$ .venv/bin/pytest tests/unit/test_py_typed.py -q
>       assert marker.is_file()
E       AssertionError: assert False
E        +  where False = is_file()
E        +    where is_file = PosixPath('.../src/py_moodle/py.typed').is_file
tests/unit/test_py_typed.py:18: AssertionError
FAILED tests/unit/test_py_typed.py::test_py_typed_marker_is_present
```

Green — after adding `src/py_moodle/py.typed` and the `[tool.setuptools.package-data]` entry:

```
$ .venv/bin/pytest tests/unit/test_py_typed.py -q
.                                                                        [100%]
```

## Test plan
- [x] New test `tests/unit/test_py_typed.py` fails before the marker exists (red).
- [x] New test passes after adding the marker + packaging (green).
- [x] Full unit suite green: `.venv/bin/pytest tests/unit -q` (all 217 pass).
- [x] `pyproject.toml` remains valid TOML (parsed successfully; `package-data = {'py_moodle': ['py.typed']}`).
- [x] Lint green: `black --check src tests`, `isort --check-only src tests`, `flake8` all clean.

## Backwards compatibility
Fully additive. The only behavioral change is that downstream type checkers now treat `py_moodle` as typed (expected PEP 561 behavior). No runtime code paths change; the marker file is empty.

## Documentation
Added a short (4-line) note to `docs/development.md` under Code Standards stating the package is PEP 561 typed via the `py.typed` marker. `docs/cli.md` is auto-generated/git-ignored and untouched.

## Notes for reviewers
Files changed (all within the assigned ownership boundary):
- `src/py_moodle/py.typed` (new, empty marker)
- `pyproject.toml` (added `[tool.setuptools.package-data]` with `py_moodle = ["py.typed"]`)
- `tests/unit/test_py_typed.py` (new test)
- `docs/development.md` (short PEP 561 note)

No other source modules, `tests/conftest.py`, `mkdocs.yml`, or forbidden docs were touched.