### PR TITLE
docs: title the site 'python-moodle' and remove py_moodle.* API headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: py-moodle
+site_name: python-moodle
 site_description: A modern Pythonic CLI and library to manage Moodle via web sessions
 site_author: Ernesto Serrano
 site_url: https://erseco.github.io/python-moodle/
@@ -74,11 +74,12 @@ plugins:
           docstring_section_style: table
           filters:
           - '!^_'
-          heading_level: 1
+          heading_level: 2
           inherited_members: true
           merge_init_into_class: true
           separate_signature: true
-          show_root_heading: true
+          show_root_heading: false
+          show_root_full_path: false
           show_signature_annotations: true
           show_source: false
           signature_crossrefs: true


### PR DESCRIPTION
## Summary
Fixes the documentation showing **`py_moodle`** as a title. It appeared in two spots: the site header/tab (`site_name: py-moodle`) and, more prominently, a redundant **`py_moodle.<module>`** heading on every API reference page (mkdocstrings rendering the fully-qualified module path under each page's own title).

## Changes (`mkdocs.yml` only)
- `site_name: py-moodle` → **`python-moodle`** (matches the PyPI/GitHub project name; header + browser tab).
- mkdocstrings options: `show_root_heading: false`, `show_root_full_path: false`, `heading_level: 2` — so each API page keeps its clean `# Course` title with members nested below, and no `py_moodle.course` heading.

## Verification
Local `mkdocs build` (reads the same `mkdocs.yml` as Zensical):
- `api/course` renders `Course` (h1) → `Attributes`/`Classes`/`Functions` (h2) → `create_course`/`MoodleCourseError`/... (h3). No visible `py_moodle.` text (it survives only as invisible anchor `id=`s).
- Browser tab: `Course - python-moodle` (was `Course - py-moodle`); home page `python-moodle`.

## Notes for reviewers
`py-moodle` (hyphen) remains the CLI command name and the logo brand — only the *documentation site title* and API headings changed. If you'd rather keep `py-moodle` as the site header brand, revert just the `site_name` line; the mkdocstrings heading fix stands on its own.