### PR TITLE
Add 'python-moodle' CLI alias and fix install docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,11 +1,17 @@
 # Installation
 
-py-moodle requires Python 3.8+ and can be installed in several ways.
+`python-moodle` requires Python 3.9+ and can be installed in several ways.
+
+!!! note "Package name vs. command name"
+    The package is published as **`python-moodle`** (that's what you `pip install`
+    and `import py_moodle`), and the CLI is available under **two equivalent
+    command names**: **`py-moodle`** and **`python-moodle`**. Use whichever you
+    prefer — every example in these docs uses `py-moodle`.
 
 ## Method 1: PyPI (Recommended)
 
 ```bash
-pip install py-moodle
+pip install python-moodle
 ```
 
 ## Method 2: From Source
@@ -14,11 +20,11 @@ Clone the repository and install:
 
 ```bash
 git clone https://github.com/erseco/python-moodle.git
-cd py-moodle
+cd python-moodle
 pip install .
 ```
 
-This makes the `py-moodle` command available system-wide.
+This makes the `py-moodle` (and `python-moodle`) command available system-wide.
 
 ## Method 3: Development Installation
 
@@ -26,7 +32,7 @@ For development or to get the latest features:
 
 ```bash
 git clone https://github.com/erseco/python-moodle.git
-cd py-moodle
+cd python-moodle
 pip install -e .
 ```
 
@@ -34,10 +40,12 @@ The `-e` flag installs in "editable" mode, so changes to the source code are imm
 
 ## Verify Installation
 
-Test that py-moodle is properly installed:
+Test that the CLI is properly installed (either command works):
 
 ```bash
 py-moodle --help
+# or, equivalently:
+python-moodle --help
 ```
 
 You should see the main help screen with available commands.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,11 +8,13 @@ Get up and running with py-moodle in minutes!
 - Access to a Moodle instance
 - Valid Moodle credentials
 
-## 1. Install py-moodle
+## 1. Install python-moodle
 
 ```bash
-pip install py-moodle
+pip install python-moodle
 ```
+
+The CLI is then available as either `py-moodle` or `python-moodle` (the examples use `py-moodle`).
 
 ## 2. Configure Credentials
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ Changelog = "https://github.com/erseco/python-moodle/releases"
 
 [project.scripts]
 py-moodle = "py_moodle.cli:app"
+# Alias so the command matches the distribution name; both are equivalent.
+python-moodle = "py_moodle.cli:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
Makes the CLI runnable as both **`py-moodle`** and **`python-moodle`**, so the command can match the distribution name, and fixes install docs that used the wrong package/directory names.

## Changes
- **`pyproject.toml`** — register `python-moodle = "py_moodle.cli:app"` as a second console-script entry point alongside `py-moodle`. Both invoke the same CLI.
- **`docs/getting-started/installation.md`** — `pip install py-moodle` → `pip install python-moodle`; `cd py-moodle` → `cd python-moodle`; "Python 3.8+" → "3.9+" (matches `requires-python = ">=3.9"`); added a note clarifying the three names (package `python-moodle`, commands `py-moodle`/`python-moodle`, import `py_moodle`).
- **`docs/getting-started/quickstart.md`** — same `pip install` fix + a note that both commands work.

## Verification
```
pip install -e . --no-deps     # regenerates console scripts
ls .venv/bin/py-moodle .venv/bin/python-moodle   # both present
python-moodle --help           # runs: "Usage: python-moodle [OPTIONS] COMMAND ..."
pytest tests/unit              # green
```
`pyproject.toml` validated as TOML (`{'py-moodle': 'py_moodle.cli:app', 'python-moodle': 'py_moodle.cli:app'}`); docs build clean.

## Backwards compatibility
Fully additive — `py-moodle` is unchanged; `python-moodle` is new. All existing docs/examples that use `py-moodle` remain correct.