### PR TITLE
docs: make 'python-moodle' the canonical command, 'py-moodle' the alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document provides **implementation and contribution guidelines** for developing new features, modules, or commands within the `py-moodle` project.
+This document provides **implementation and contribution guidelines** for developing new features, modules, or commands within the `python-moodle` project.
 It is designed for both human developers and AI agents that will generate, review, or maintain code in this repository.
 
 ---
@@ -182,23 +182,23 @@ Rules for integration tests:
 
 ## Supported Commands and Features
 
-The CLI uses a subcommand structure. For example, `py-moodle courses list`.
+The CLI uses a subcommand structure. For example, `python-moodle courses list`.
 
 ```sh
 # List all courses
-py-moodle courses list
+python-moodle courses list
 
 # Show details for a specific course
-py-moodle courses show <course-id>
+python-moodle courses show <course-id>
 
 # Create a new course
-py-moodle courses create --fullname "My New Course" --shortname "mynewcourse"
+python-moodle courses create --fullname "My New Course" --shortname "mynewcourse"
 
 # Delete a course
-py-moodle courses delete <course-id>
+python-moodle courses delete <course-id>
 
 # Add a new label to a course section
-py-moodle modules add label <course-id> <section-id> --name "My Label" --intro "Label content"
+python-moodle modules add label <course-id> <section-id> --name "My Label" --intro "Label content"
 ```
 
 ### Capabilities and Webservice Limitations
@@ -342,7 +342,7 @@ MOODLE_PROD_WS_TOKEN=***
 
 ## Naming
 
-The project name is `py-moodle`. If you later publish to PyPI, ensure the name does not clash with Selenium- or API token-based Moodle tools.
+The project name is `python-moodle`. If you later publish to PyPI, ensure the name does not clash with Selenium- or API token-based Moodle tools.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 	flake8
 
 docs:
-	python -m typer py_moodle.cli.app utils docs --output docs/cli.md --name py-moodle
+	python -m typer py_moodle.cli.app utils docs --output docs/cli.md --name python-moodle
 	zensical build
 
 test-unit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/erseco/python-moodle/main/docs/images/py-moodle-icon.png" alt="py-moodle logo" width="128">
+  <img src="https://raw.githubusercontent.com/erseco/python-moodle/main/docs/images/py-moodle-icon.png" alt="python-moodle logo" width="128">
 </p>
 
 # python-moodle
@@ -39,15 +39,15 @@
 pip install python-moodle
 cp .env.example .env
 # Edit .env with your Moodle URL and credentials
-py-moodle courses list
+python-moodle courses list
 ```
 
 ### Typical automation tasks
 
 | Task                          | Command / Use case                            |
 | ----------------------------- | --------------------------------------------- |
-| Bulk course creation          | `py-moodle courses create`                    |
-| SCORM upload pipelines        | `py-moodle modules add scorm`                 |
+| Bulk course creation          | `python-moodle courses create`                    |
+| SCORM upload pipelines        | `python-moodle modules add scorm`                 |
 | Content migration             | Script with `list_courses` + `create_course`  |
 | Moodle smoke tests in CI      | `pytest` + `MoodleSession` fixture            |
 | Admin scripting across instances | `--env` flag with multiple `.env` profiles |
@@ -57,7 +57,7 @@ py-moodle courses list
 !!! warning "Experimental"
     This library is under active development. Use a test Moodle instance and back up data before running commands that create, modify, or delete content.
 
-`py-moodle` allows you to automate tedious Moodle tasks—like creating courses, uploading content, and managing modules—directly from your terminal or in your Python scripts. It works by simulating a real user's web session, so it doesn't require API tokens or special Moodle plugins.
+`python-moodle` allows you to automate tedious Moodle tasks—like creating courses, uploading content, and managing modules—directly from your terminal or in your Python scripts. It works by simulating a real user's web session, so it doesn't require API tokens or special Moodle plugins.
 
 ---
 
@@ -69,7 +69,7 @@ py-moodle courses list
 -   **Authentication**: Supports standard Moodle login and SSO/CAS authentication.
 -   **Dual Use**: Can be used as a powerful CLI or imported as a library into your own Python projects.
 -   **High-level `MoodleClient` facade**: A discoverable, object-oriented API (`moodle.courses.list()`, `moodle.scorm.add(...)`) over the function-based library, plus opt-in typed domain models (`Course`, `User`, `Folder`, ...) for IDE autocompletion.
--   **Diagnostics**: `py-moodle doctor run` checks base URL reachability, login, sesskey/webservice token availability, and more in one command.
+-   **Diagnostics**: `python-moodle doctor run` checks base URL reachability, login, sesskey/webservice token availability, and more in one command.
 -   **Idempotent automation**: `courses ensure` creates a course only if it doesn't already exist, safe to run repeatedly in CI/onboarding scripts.
 -   **Safe previews**: `--dry-run` on `courses create`, `courses delete`, and `modules add scorm` shows the planned action without touching Moodle.
 -   **Scripting-friendly output**: `--output table|json|yaml|csv`, plus `--quiet`, `--no-color`, `--verbose`, and `--debug` (with automatic secret redaction) for CI pipelines and shell automation.
@@ -80,7 +80,7 @@ py-moodle courses list
 
 ## Moodle Compatibility
 
-`py-moodle` interacts with Moodle through authenticated web sessions, HTML forms, and page parsing. To make those flows more resilient across Moodle releases, the library now centralizes version-sensitive logic in `py_moodle.compat`.
+`python-moodle` interacts with Moodle through authenticated web sessions, HTML forms, and page parsing. To make those flows more resilient across Moodle releases, the library now centralizes version-sensitive logic in `py_moodle.compat`.
 
 -   **Version detection** happens during login/session initialization. The library first tries `core_webservice_get_site_info` when a webservice token is available, then falls back to probing the dashboard HTML (`/my/`) for Moodle release metadata.
 -   **Version-aware strategies** are grouped into compatibility ranges instead of scattering selectors throughout the codebase. The current built-in strategies cover legacy Moodle 3.x layouts and modern Moodle 4.x/5.x layouts.
@@ -136,17 +136,17 @@ MOODLE_PROD_PASSWORD=your_super_secret_password
 # MOODLE_PROD_WS_TOKEN=your_webservice_token
 ```
 
-Use the `--env` flag or the `MOODLE_ENV` variable to select the environment, e.g. `py-moodle --env prod courses list`.
+Use the `--env` flag or the `MOODLE_ENV` variable to select the environment, e.g. `python-moodle --env prod courses list`.
 
 > **Note**: For local development, you can quickly spin up a Moodle instance using the provided `docker-compose.yml`: `docker-compose up -d`.
 
-If something is not working for a given environment, run `py-moodle --env prod doctor run` to check base URL reachability, login, sesskey/webservice token availability, and a few other diagnostics in one command (see the [Recipes](https://erseco.github.io/python-moodle/recipes/#diagnosing-a-broken-environment) page for details).
+If something is not working for a given environment, run `python-moodle --env prod doctor run` to check base URL reachability, login, sesskey/webservice token availability, and a few other diagnostics in one command (see the [Recipes](https://erseco.github.io/python-moodle/recipes/#diagnosing-a-broken-environment) page for details).
 
 ---
 
 ## CLI Usage
 
-Once installed, all functionality is available through the `py-moodle` command. Every command and subcommand includes detailed help with the `-h` or `--help` flag.
+Once installed, all functionality is available through the `python-moodle` command (or its shorter alias `py-moodle`). Every command and subcommand includes detailed help with the `-h` or `--help` flag.
 
 ### Common Commands
 
@@ -155,7 +155,7 @@ Here are a few examples of common commands:
 **List all available courses:**
 
 ```bash
-py-moodle courses list
+python-moodle courses list
 ```
 
 *Output:*
@@ -172,32 +172,32 @@ py-moodle courses list
 **Show the structure of a single course:**
 
 ```bash
-py-moodle courses show 2
+python-moodle courses show 2
 ```
 
 **Create a new course:**
 
 ```bash
-py-moodle courses create --fullname "My New Automated Course" --shortname "auto-course-01"
+python-moodle courses create --fullname "My New Automated Course" --shortname "auto-course-01"
 ```
 
 **Add a label to a course section:**
 
 ```bash
-py-moodle modules add label --course-id 2 --section-id 1 --name "Welcome" --intro "<h1>Welcome to the course!</h1>"
+python-moodle modules add label --course-id 2 --section-id 1 --name "Welcome" --intro "<h1>Welcome to the course!</h1>"
 ```
 
 **Upload a SCORM package to a course:**
 
 ```bash
-py-moodle modules add scorm --course-id 2 --section-id 1 --name "My SCORM Package" --path "path/to/your/scorm.zip"
+python-moodle modules add scorm --course-id 2 --section-id 1 --name "My SCORM Package" --path "path/to/your/scorm.zip"
 ```
 
 ---
 
 ## Library Usage (Automation Scripting)
 
-You can also import `py-moodle`'s functions into your own Python scripts to automate complex workflows. The `example_script.py` file provides a comprehensive tutorial.
+You can also import `python-moodle`'s functions into your own Python scripts to automate complex workflows. The `example_script.py` file provides a comprehensive tutorial.
 
 ### Quick Example
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Welcome to py-moodle development! This guide covers everything you need to contribute to the project.
+Welcome to python-moodle development! This guide covers everything you need to contribute to the project.
 
 ## Development Setup
 
@@ -8,7 +8,7 @@ Welcome to py-moodle development! This guide covers everything you need to contr
 
 ```bash
 git clone https://github.com/erseco/python-moodle.git
-cd py-moodle
+cd python-moodle
 
 # Create virtual environment
 python -m venv env
@@ -117,7 +117,7 @@ modules is tracked as follow-up work.
 
 ### Transport Strategies
 
-`src/py_moodle/transport/` formalizes the three ways `py-moodle` talks to
+`src/py_moodle/transport/` formalizes the three ways `python-moodle` talks to
 Moodle as explicit, independently testable strategy modules built on top
 of `http.py`:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-This page contains practical examples of using py-moodle for common tasks.
+This page contains practical examples of using python-moodle for common tasks.
 
 ## Course Management Examples
 
@@ -9,7 +9,7 @@ This page contains practical examples of using py-moodle for common tasks.
 ```bash
 # Create courses from a list
 for course in "Math 101" "Physics 201" "Chemistry 301"; do
-    py-moodle courses create --fullname "$course" --shortname "$(echo $course | tr ' ' '-' | tr '[:upper:]' '[:lower:]')"
+    python-moodle courses create --fullname "$course" --shortname "$(echo $course | tr ' ' '-' | tr '[:upper:]' '[:lower:]')"
 done
 ```
 
@@ -19,7 +19,7 @@ done
 # Add welcome labels to all sections of a course
 course_id=2
 for section in {1..5}; do
-    py-moodle modules add label \
+    python-moodle modules add label \
         --course-id $course_id \
         --section-id $section \
         --name "Section $section Welcome" \
@@ -38,11 +38,11 @@ section_id=1
 folder_name="Course Materials"
 
 # Create the folder first
-py-moodle modules add folder --course-id $course_id --section-id $section_id --name "$folder_name"
+python-moodle modules add folder --course-id $course_id --section-id $section_id --name "$folder_name"
 
 # Upload files (you'll need to get the folder ID from the output above)
 for file in *.pdf; do
-    py-moodle files upload --course-id $course_id --file "$file"
+    python-moodle files upload --course-id $course_id --file "$file"
 done
 ```
 
@@ -50,7 +50,7 @@ done
 
 ```bash
 # Upload and configure a SCORM package
-py-moodle modules add scorm \
+python-moodle modules add scorm \
     --course-id 2 \
     --section-id 1 \
     --name "Interactive Lesson 1" \

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-py-moodle uses environment variables for configuration, typically stored in a `.env` file.
+python-moodle uses environment variables for configuration, typically stored in a `.env` file.
 
 ## Setting Up Credentials
 
@@ -42,9 +42,9 @@ py-moodle uses environment variables for configuration, typically stored in a `.
 Choose which environment configuration to use with the `--env` option or by setting `MOODLE_ENV`.
 
 ```bash
-MOODLE_ENV=prod py-moodle courses list
+MOODLE_ENV=prod python-moodle courses list
 # or
-py-moodle --env prod courses list
+python-moodle --env prod courses list
 ```
 
 If omitted, the environment defaults to `local`.
@@ -54,7 +54,7 @@ If omitted, the environment defaults to `local`.
 Verify your credentials work:
 
 ```bash
-py-moodle courses list
+python-moodle courses list
 ```
 
 If configured correctly, you should see a list of available courses.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,16 +1,16 @@
 # Getting Started
 
-Welcome to py-moodle! This section will help you get up and running quickly.
+Welcome to python-moodle! This section will help you get up and running quickly.
 
-## What is py-moodle?
+## What is python-moodle?
 
-py-moodle is a modern Pythonic CLI and library that allows you to manage Moodle instances via web sessions. It provides both a command-line interface and a Python library for automating Moodle tasks.
+python-moodle is a modern Pythonic CLI and library that allows you to manage Moodle instances via web sessions. It provides both a command-line interface and a Python library for automating Moodle tasks.
 
 ## Quick Navigation
 
-- **[Installation](installation.md)** - Install py-moodle on your system
+- **[Installation](installation.md)** - Install python-moodle on your system
 - **[Configuration](configuration.md)** - Set up your Moodle credentials
-- **[Quick Start](quickstart.md)** - Your first py-moodle commands
+- **[Quick Start](quickstart.md)** - Your first python-moodle commands
 
 ## Key Features
 
@@ -21,4 +21,4 @@ py-moodle is a modern Pythonic CLI and library that allows you to manage Moodle 
 - ✅ **Multiple content types** - Folders, assignments, SCORM, and more
 
 !!! tip "New to Moodle automation?"
-    Start with the [Quick Start](quickstart.md) guide to see py-moodle in action within minutes.
+    Start with the [Quick Start](quickstart.md) guide to see python-moodle in action within minutes.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,8 +5,8 @@
 !!! note "Package name vs. command name"
     The package is published as **`python-moodle`** (that's what you `pip install`
     and `import py_moodle`), and the CLI is available under **two equivalent
-    command names**: **`py-moodle`** and **`python-moodle`**. Use whichever you
-    prefer — every example in these docs uses `py-moodle`.
+    command names**: **`python-moodle`** (used throughout these docs) and the
+    shorter alias **`py-moodle`**. Use whichever you prefer.
 
 ## Method 1: PyPI (Recommended)
 
@@ -24,7 +24,7 @@ cd python-moodle
 pip install .
 ```
 
-This makes the `py-moodle` (and `python-moodle`) command available system-wide.
+This makes the `python-moodle` command (and its `py-moodle` alias) available system-wide.
 
 ## Method 3: Development Installation
 
@@ -43,9 +43,9 @@ The `-e` flag installs in "editable" mode, so changes to the source code are imm
 Test that the CLI is properly installed (either command works):
 
 ```bash
-py-moodle --help
-# or, equivalently:
 python-moodle --help
+# or, equivalently, the shorter alias:
+py-moodle --help
 ```
 
 You should see the main help screen with available commands.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Get up and running with py-moodle in minutes!
+Get up and running with python-moodle in minutes!
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ Get up and running with py-moodle in minutes!
 pip install python-moodle
 ```
 
-The CLI is then available as either `py-moodle` or `python-moodle` (the examples use `py-moodle`).
+The CLI is then available as `python-moodle` (used in the examples below) or its shorter alias `py-moodle`.
 
 ## 2. Configure Credentials
 
@@ -42,7 +42,7 @@ Select this environment by running commands with `--env prod` or by setting `MOO
 List all available courses:
 
 ```bash
-py-moodle courses list
+python-moodle courses list
 ```
 
 You should see output like:
@@ -60,22 +60,22 @@ You should see output like:
 
 **Show course details:**
 ```bash
-py-moodle courses show 2
+python-moodle courses show 2
 ```
 
 **Create a new course:**
 ```bash
-py-moodle courses create --fullname "Test Course" --shortname "test-001"
+python-moodle courses create --fullname "Test Course" --shortname "test-001"
 ```
 
 **Add content to a course:**
 ```bash
-py-moodle modules add label --course-id 2 --section-id 1 --name "Welcome" --intro "Welcome to the course!"
+python-moodle modules add label --course-id 2 --section-id 1 --name "Welcome" --intro "Welcome to the course!"
 ```
 
-## 5. Use py-moodle as a Library
+## 5. Use python-moodle as a Library
 
-Besides the CLI, py-moodle can be used directly from Python scripts.
+Besides the CLI, python-moodle can be used directly from Python scripts.
 
 The low-level modules (`course.py`, `section.py`, `folder.py`, etc.) expose
 plain functions that take `session`, `base_url`, `token` and `sesskey`
@@ -117,7 +117,7 @@ resource namespaces.
 
 - Check out the [CLI Reference](../cli.md) for all available commands
 - Read the [Configuration](configuration.md) guide for advanced setup
-- Browse [API Reference](../api/client.md) to use py-moodle as a library
+- Browse [API Reference](../api/client.md) to use python-moodle as a library
 
 !!! tip "Need Help?"
-    Use `py-moodle --help` or `py-moodle COMMAND --help` for detailed command information.
+    Use `python-moodle --help` or `python-moodle COMMAND --help` for detailed command information.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,6 +1,6 @@
 # Recipes
 
-This page collects task-oriented workflows for common `py-moodle` jobs.
+This page collects task-oriented workflows for common `python-moodle` jobs.
 Use these recipes when you want a copy/paste starting point instead of a full
 command reference.
 
@@ -11,7 +11,7 @@ different Moodle environment.
 
 ```bash
 # Use the environment from MOODLE_ENV or pass one explicitly.
-py-moodle --env local site info
+python-moodle --env local site info
 ```
 
 If the command succeeds, your credentials, session bootstrap, and base URL are
@@ -33,13 +33,13 @@ login, sesskey, webservice token, webservice reachability, upload endpoint,
 and a few other derived facts.
 
 ```bash
-py-moodle --env prod doctor run
+python-moodle --env prod doctor run
 ```
 
 Machine-readable output is useful in CI or before running bulk operations:
 
 ```bash
-py-moodle --env prod doctor run --output json
+python-moodle --env prod doctor run --output json
 ```
 
 Each row is one independent check with a `pass`, `warn`, or `fail` status:
@@ -64,13 +64,13 @@ before creating or deleting content.
 
 ```bash
 # Find the course ID you want to work with.
-py-moodle courses list
+python-moodle courses list
 
 # Inspect one course in detail.
-py-moodle courses show 2
+python-moodle courses show 2
 
 # List its sections before adding modules.
-py-moodle sections list 2
+python-moodle sections list 2
 ```
 
 This flow is useful for scripts and manual operations because it reduces the
@@ -85,10 +85,10 @@ it can be redirected straight into a file or another tool.
 
 ```bash
 # Save the course list as a CSV file for a spreadsheet.
-py-moodle courses list --output csv > courses.csv
+python-moodle courses list --output csv > courses.csv
 
 # Pipe user emails into another shell tool.
-py-moodle users list --course-id 2 --output csv | cut -d, -f3
+python-moodle users list --course-id 2 --output csv | cut -d, -f3
 ```
 
 ## Select only the fields you need with `--fields`
@@ -101,13 +101,13 @@ you a stable, minimal shape for automation.
 
 ```bash
 # Only the id and shortname of every course, as JSON, in that order.
-py-moodle courses list --output json --fields id,shortname
+python-moodle courses list --output json --fields id,shortname
 
 # The same projection as CSV (the selected fields become the columns).
-py-moodle courses list --output csv --fields id,shortname > courses.csv
+python-moodle courses list --output csv --fields id,shortname > courses.csv
 
 # Field order follows what you pass, so this puts shortname first.
-py-moodle courses list --output json --fields shortname,id
+python-moodle courses list --output json --fields shortname,id
 ```
 
 Notes:
@@ -120,7 +120,7 @@ Notes:
 - Passing an empty value (`--fields ""`) is treated as "no filtering",
   identical to omitting the flag.
 
-## Automate `py-moodle` in scripts and CI jobs
+## Automate `python-moodle` in scripts and CI jobs
 
 Combine `--quiet`, `--no-color`, and `--output csv`/`--output json` to keep
 automated output clean and machine-readable. `--quiet` suppresses incidental
@@ -130,16 +130,16 @@ strips ANSI styling from table output.
 
 ```bash
 # A CI-friendly invocation: no banners, no color, CSV on stdout.
-py-moodle --quiet --no-color courses list --output csv
+python-moodle --quiet --no-color courses list --output csv
 
 # Diagnose a failing login without leaking secrets into logs: tokens,
 # session keys, and passwords are always redacted from --verbose/--debug
 # output.
-py-moodle --debug site info
+python-moodle --debug site info
 ```
 
 Errors are always written to stderr, never mixed into `--output json`/`csv`
-stdout, so `courses=$(py-moodle courses list --output json)` is safe to use
+stdout, so `courses=$(python-moodle courses list --output json)` is safe to use
 even when the command fails.
 
 ## Create a course and add a welcome label
@@ -148,15 +148,15 @@ This is a minimal end-to-end content bootstrap workflow.
 
 ```bash
 # 1. Create the course.
-py-moodle courses create \
+python-moodle courses create \
   --fullname "Automation Demo" \
   --shortname "automation-demo"
 
 # 2. Create a section if you need one beyond the default course layout.
-py-moodle sections create 2 --name "Getting Started"
+python-moodle sections create 2 --name "Getting Started"
 
 # 3. Add a welcome label to the first section.
-py-moodle modules add label \
+python-moodle modules add label \
   --course-id 2 \
   --section-id 1 \
   --name "Welcome" \
@@ -195,16 +195,16 @@ materials area.
 
 ```bash
 # Create a folder activity in the course.
-py-moodle folders add \
+python-moodle folders add \
   --course-id 2 \
   --section-id 1 \
   --name "Course Materials"
 
 # Upload a file into the folder activity.
-py-moodle folders add-file 15 ./docs/syllabus.pdf
+python-moodle folders add-file 15 ./docs/syllabus.pdf
 
 # Confirm the folder contents.
-py-moodle folders list-content 15
+python-moodle folders list-content 15
 ```
 
 In this recipe, `15` is the folder module ID returned by the add command.
@@ -218,16 +218,16 @@ plan before running it for real.
 
 ```bash
 # Preview a course creation without calling Moodle.
-py-moodle courses create \
+python-moodle courses create \
   --fullname "Automation Demo" \
   --shortname "automation-demo" \
   --dry-run --output json
 
 # Preview a deletion; no confirmation prompt is shown in dry-run mode.
-py-moodle courses delete 42 --dry-run --output json
+python-moodle courses delete 42 --dry-run --output json
 
 # Preview a SCORM upload without uploading the package.
-py-moodle modules add scorm \
+python-moodle modules add scorm \
   --course-id 2 \
   --section-id 1 \
   --name "SCORM 1" \
@@ -247,7 +247,7 @@ provision a course without failing (or creating duplicates) on repeat runs.
 
 ```bash
 # Safe to run every time: creates the course only if it is missing.
-py-moodle courses ensure \
+python-moodle courses ensure \
   --shortname "ci-smoke-test" \
   --fullname "CI Smoke Test" \
   --category-id 1
@@ -260,7 +260,7 @@ different `--fullname`/`--category-id`, the command reports
 letting you inspect the `differences` before deciding what to do:
 
 ```bash
-py-moodle courses ensure \
+python-moodle courses ensure \
   --shortname "ci-smoke-test" \
   --fullname "Renamed CI Smoke Test" \
   --category-id 1 \
@@ -271,7 +271,7 @@ Pass `--update` to have the command bring `fullname`/`--category-id` in line
 with the request instead of reporting a conflict:
 
 ```bash
-py-moodle courses ensure \
+python-moodle courses ensure \
   --shortname "ci-smoke-test" \
   --fullname "Renamed CI Smoke Test" \
   --category-id 1 \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting
 
 This guide covers the most common authentication, session, and test setup
-problems when working with `py-moodle`.
+problems when working with `python-moodle`.
 
 ## Authentication and Session Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ Issues = "https://github.com/erseco/python-moodle/issues"
 Changelog = "https://github.com/erseco/python-moodle/releases"
 
 [project.scripts]
-py-moodle = "py_moodle.cli:app"
-# Alias so the command matches the distribution name; both are equivalent.
+# Canonical command matches the distribution name; py-moodle is a shorter alias.
 python-moodle = "py_moodle.cli:app"
+py-moodle = "py_moodle.cli:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
Follows #83 (which added the `python-moodle` console-script alias). Now uses **`python-moodle`** as the canonical command everywhere in the docs and documents **`py-moodle`** as the shorter alias, so the command name matches the package name.

## Changes
- **All command examples** across `README.md` and `docs/**` (`courses`/`users`/`site`/`modules`/`sections`/`recipes`/etc.) now use `python-moodle ...`; prose references to the tool use `python-moodle`.
- The **alias is documented** as the shorter equivalent `py-moodle` (installation & quickstart notes, README intro).
- **`pyproject.toml`**: list `python-moodle` first (canonical), `py-moodle` second (alias) — both still map to `py_moodle.cli:app`.
- **`Makefile`**: generate the CLI reference (`docs/cli.md`) with `--name python-moodle`, so the auto-generated help shows the canonical command.
- **Preserved**: the `py-moodle-icon.png` logo asset and the `py_moodle` import name. Also fixed a stray `cd py-moodle` and an inaccurate "project name is py-moodle" → `python-moodle`.

## Verification
```
python -m typer py_moodle.cli.app utils docs --name python-moodle   # cli.md -> "python-moodle courses ..."
pyproject scripts == {python-moodle, py-moodle} -> py_moodle.cli:app
mkdocs build                                                        # clean; no stray "py-moodle <subcommand>" in rendered HTML
pytest tests/unit && flake8                                         # green
```

## Backwards compatibility
Fully compatible — both commands still work; only the *documented default* changed. `py-moodle` remains a first-class alias.