### PR TITLE
Add Rich progress and centralized CLI feedback

### DIFF
--- a/src/py_moodle/cli/feedback.py
+++ b/src/py_moodle/cli/feedback.py
@@ -1,0 +1,110 @@
+"""Shared Rich feedback helpers for the ``py-moodle`` CLI."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+import typer
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TransferSpeedColumn,
+)
+
+from py_moodle.cli.output import OutputFormat, get_console
+
+
+def _is_quiet(ctx: Optional[typer.Context]) -> bool:
+    """Return whether incidental CLI feedback should be suppressed."""
+    return bool(ctx is not None and ctx.obj and ctx.obj.get("quiet"))
+
+
+def _human_output(output_format: OutputFormat) -> bool:
+    """Return whether the selected output format is intended for humans."""
+    return output_format == OutputFormat.TABLE
+
+
+def success(ctx: Optional[typer.Context], message: str) -> None:
+    """Render a success message unless ``--quiet`` is active."""
+    if _is_quiet(ctx):
+        return
+    get_console(ctx).print(f"[green]✓[/green] {message}")
+
+
+def warning(ctx: Optional[typer.Context], message: str) -> None:
+    """Render a warning message unless ``--quiet`` is active."""
+    if _is_quiet(ctx):
+        return
+    get_console(ctx).print(f"[yellow]![/yellow] {message}")
+
+
+def error(ctx: Optional[typer.Context], message: str) -> None:
+    """Render an error message to stderr; errors are never suppressed."""
+    console = get_console(ctx)
+    original_file = console.file
+    try:
+        console.file = typer.get_text_stderr()
+        console.print(f"[red]✗[/red] {message}")
+    finally:
+        console.file = original_file
+
+
+@contextmanager
+def status(
+    ctx: Optional[typer.Context],
+    message: str,
+    output_format: OutputFormat = OutputFormat.TABLE,
+) -> Iterator[None]:
+    """Show a spinner for slow human-facing operations when appropriate."""
+    console = get_console(ctx)
+    if _is_quiet(ctx) or not _human_output(output_format) or not console.is_terminal:
+        with nullcontext():
+            yield
+        return
+
+    with console.status(message, spinner="dots"):
+        yield
+
+
+@contextmanager
+def upload_progress(
+    ctx: Optional[typer.Context],
+    file_path: str,
+    description: Optional[str] = None,
+    output_format: OutputFormat = OutputFormat.TABLE,
+) -> Iterator[Callable[[int], None]]:
+    """Yield a byte-progress callback backed by Rich when output is interactive.
+
+    The returned callback is always safe to call. In quiet mode, non-table output,
+    or when stdout is not a TTY, it becomes a no-op so JSON/YAML/CSV and shell
+    pipelines remain unchanged.
+    """
+    console = get_console(ctx)
+    if _is_quiet(ctx) or not _human_output(output_format) or not console.is_terminal:
+        yield lambda _bytes: None
+        return
+
+    path = Path(file_path)
+    progress = Progress(
+        TextColumn("{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TransferSpeedColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    )
+    task_id = progress.add_task(
+        description or f"Uploading {path.name}",
+        total=path.stat().st_size,
+    )
+
+    with progress:
+        yield lambda bytes_uploaded: progress.update(task_id, advance=bytes_uploaded)
+
+
+__all__ = ["error", "status", "success", "upload_progress", "warning"]

--- a/src/py_moodle/cli/feedback.py
+++ b/src/py_moodle/cli/feedback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Callable, Iterator, Optional
@@ -48,7 +49,7 @@ def error(ctx: Optional[typer.Context], message: str) -> None:
     console = get_console(ctx)
     original_file = console.file
     try:
-        console.file = typer.get_text_stderr()
+        console.file = sys.stderr
         console.print(f"[red]✗[/red] {message}")
     finally:
         console.file = original_file

--- a/src/py_moodle/cli/folders.py
+++ b/src/py_moodle/cli/folders.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import List
 
 import typer
-from rich.console import Console
 from rich.table import Table
 
+from py_moodle.cli.feedback import error, status, success, upload_progress, warning
+from py_moodle.cli.output import get_console
 from py_moodle.draftfile import MoodleDraftFileError, upload_file_to_draft_area
 from py_moodle.folder import (
     MoodleFolderError,
@@ -21,7 +22,6 @@ from py_moodle.folder import (
 )
 from py_moodle.session import MoodleSession
 
-# --- CLI App for "folders" command ---
 app = typer.Typer(
     help="Manage folder modules: create, delete, and manage their content.",
     no_args_is_help=True,
@@ -47,23 +47,17 @@ def add_a_folder(
         None, "--file", help="Path to a file to include. Can be used multiple times."
     ),
 ):
-    """
-    Adds a new folder to a course section, optionally with initial files.
-    """
+    """Add a new folder to a course section, optionally with initial files."""
     ms = MoodleSession.get(ctx.obj["env"])
-    console = Console()
+    files_itemid = int(time.time() * 1000)
 
-    files_itemid = int(time.time() * 1000)  # Unique draft area for this new folder
-
-    # Upload files if any are provided
     if files:
         try:
-            context_id = get_course_context_id(ms, course_id)
-            with console.status(
-                "[bold green]Uploading files...[/bold green]", spinner="dots"
-            ) as status:
-                for file_item in files:
-                    status.update(f"Uploading {file_item.name}...")
+            with status(ctx, "Preparing folder upload..."):
+                context_id = get_course_context_id(ms, course_id)
+
+            for file_item in files:
+                with upload_progress(ctx, file_item.name) as progress_callback:
                     upload_file_to_draft_area(
                         ms.session,
                         ms.settings.url,
@@ -72,19 +66,15 @@ def add_a_folder(
                         context_id,
                         file_item.name,
                         itemid=files_itemid,
+                        progress_callback=progress_callback,
                     )
-            console.print(
-                f"✅ [green]All files uploaded to draft area {files_itemid}.[/green]"
-            )
+            success(ctx, f"Uploaded {len(files)} file(s) to the folder draft area.")
         except (MoodleDraftFileError, MoodleFolderError) as e:
-            console.print(f"❌ [bold red]Error during file upload:[/bold red] {e}")
+            error(ctx, f"Error during file upload: {e}")
             raise typer.Exit(1)
 
-    # Create the folder
     try:
-        with console.status(
-            "[bold green]Creating folder module...[/bold green]", spinner="dots"
-        ):
+        with status(ctx, "Creating folder module..."):
             new_cmid = add_folder(
                 session=ms.session,
                 base_url=ms.settings.url,
@@ -95,12 +85,9 @@ def add_a_folder(
                 intro_html=intro,
                 files_itemid=files_itemid,
             )
-        console.print(
-            f"✅ [bold green]Folder '{name}' created successfully![/bold green]"
-        )
-        console.print(f"New course module ID (cmid): {new_cmid}")
+        success(ctx, f"Folder '{name}' created. New module ID (cmid): {new_cmid}")
     except MoodleFolderError as e:
-        console.print(f"❌ [bold red]Error creating folder:[/bold red] {e}")
+        error(ctx, f"Error creating folder: {e}")
         raise typer.Exit(1)
 
 
@@ -112,9 +99,7 @@ def delete_a_folder(
         False, "--force", "-f", help="Delete without confirmation."
     ),
 ):
-    """
-    Deletes a folder module from a course.
-    """
+    """Delete a folder module from a course."""
     ms = MoodleSession.get(ctx.obj["env"])
     if not force:
         typer.confirm(
@@ -123,10 +108,11 @@ def delete_a_folder(
         )
 
     try:
-        delete_folder(ms.session, ms.settings.url, ms.sesskey, cmid)
-        typer.echo(f"Folder {cmid} deleted successfully.")
+        with status(ctx, f"Deleting folder {cmid}..."):
+            delete_folder(ms.session, ms.settings.url, ms.sesskey, cmid)
+        success(ctx, f"Folder {cmid} deleted successfully.")
     except MoodleFolderError as e:
-        typer.echo(f"Error deleting folder: {e}", err=True)
+        error(ctx, f"Error deleting folder: {e}")
         raise typer.Exit(1)
 
 
@@ -135,13 +121,11 @@ def list_folder_files(
     ctx: typer.Context,
     cmid: int = typer.Argument(..., help="ID of the folder module (cmid) to inspect."),
 ):
-    """
-    Lists the files and subdirectories inside a folder.
-    """
+    """List the files and subdirectories inside a folder."""
     ms = MoodleSession.get(ctx.obj["env"])
-    console = Console()
+    console = get_console(ctx)
     try:
-        with console.status("[green]Fetching folder content...[/green]"):
+        with status(ctx, "Fetching folder content..."):
             content = list_folder_content(ms.session, ms.settings.url, cmid)
 
         table = Table(
@@ -152,7 +136,7 @@ def list_folder_files(
         table.add_column("Filename", style="cyan")
 
         if not content:
-            console.print(f"[yellow]Folder {cmid} is empty.[/yellow]")
+            warning(ctx, f"Folder {cmid} is empty.")
             return
 
         for item in content:
@@ -161,7 +145,7 @@ def list_folder_files(
         console.print(table)
 
     except MoodleFolderError as e:
-        console.print(f"❌ [bold red]Error listing folder content:[/bold red] {e}")
+        error(ctx, f"Error listing folder content: {e}")
         raise typer.Exit(1)
 
 
@@ -180,35 +164,36 @@ def add_file(
         help="Path to the subfolder inside the Moodle folder (e.g., '/scorms/'). Must start and end with '/'.",
     ),
 ):
-    """Adds a file to an existing folder."""
+    """Add a file to an existing folder."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        # --- CHANGE HERE ---
-        # Capture the tuple with the status and final filename
-        success, final_filename = add_file_to_folder(
-            ms.session,
-            ms.settings.url,
-            ms.sesskey,
-            cmid,
-            file_path.name,
-            subfolder=subfolder,
-        )
+        with upload_progress(ctx, file_path.name) as progress_callback:
+            uploaded, final_filename = add_file_to_folder(
+                ms.session,
+                ms.settings.url,
+                ms.sesskey,
+                cmid,
+                file_path.name,
+                subfolder=subfolder,
+                progress_callback=progress_callback,
+            )
 
-        if success:
+        if uploaded:
             original_filename = Path(file_path.name).name
             if final_filename != original_filename:
-                # If the name changed, inform the user.
-                typer.echo(
-                    f"File '{original_filename}' already existed and was uploaded as '{final_filename}' to folder {cmid}."
+                warning(
+                    ctx,
+                    f"File '{original_filename}' already existed and was uploaded as "
+                    f"'{final_filename}' to folder {cmid}.",
                 )
             else:
-                typer.echo(
-                    f"File '{original_filename}' added successfully to folder {cmid}."
+                success(
+                    ctx,
+                    f"File '{original_filename}' added successfully to folder {cmid}.",
                 )
-        # No 'else' needed because a False 'success' will raise an exception
 
     except MoodleFolderError as e:
-        typer.echo(f"Error adding file: {e}", err=True)
+        error(ctx, f"Error adding file: {e}")
         raise typer.Exit(1)
 
 
@@ -225,7 +210,7 @@ def delete_file(
         False, "--force", "-f", help="Delete without confirmation."
     ),
 ):
-    """Deletes a file from an existing folder."""
+    """Delete a file from an existing folder."""
     ms = MoodleSession.get(ctx.obj["env"])
     if not force:
         typer.confirm(
@@ -234,10 +219,13 @@ def delete_file(
         )
 
     try:
-        delete_file_from_folder(ms.session, ms.settings.url, ms.sesskey, cmid, filename)
-        typer.echo(f"File '{filename}' deleted successfully from folder {cmid}.")
+        with status(ctx, f"Deleting '{filename}'..."):
+            delete_file_from_folder(
+                ms.session, ms.settings.url, ms.sesskey, cmid, filename
+            )
+        success(ctx, f"File '{filename}' deleted successfully from folder {cmid}.")
     except MoodleFolderError as e:
-        typer.echo(f"Error deleting file: {e}", err=True)
+        error(ctx, f"Error deleting file: {e}")
         raise typer.Exit(1)
 
 
@@ -252,15 +240,16 @@ def rename_file(
     ),
     new_name: str = typer.Option(..., "--new-name", help="The new name for the file."),
 ):
-    """Renames a file inside an existing folder."""
+    """Rename a file inside an existing folder."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        rename_file_in_folder(
-            ms.session, ms.settings.url, ms.sesskey, cmid, old_name, new_name
-        )
-        typer.echo(f"File renamed from '{old_name}' to '{new_name}' in folder {cmid}.")
+        with status(ctx, f"Renaming '{old_name}'..."):
+            rename_file_in_folder(
+                ms.session, ms.settings.url, ms.sesskey, cmid, old_name, new_name
+            )
+        success(ctx, f"File renamed from '{old_name}' to '{new_name}' in folder {cmid}.")
     except MoodleFolderError as e:
-        typer.echo(f"Error renaming file: {e}", err=True)
+        error(ctx, f"Error renaming file: {e}")
         raise typer.Exit(1)
 
 

--- a/src/py_moodle/cli/folders.py
+++ b/src/py_moodle/cli/folders.py
@@ -247,7 +247,10 @@ def rename_file(
             rename_file_in_folder(
                 ms.session, ms.settings.url, ms.sesskey, cmid, old_name, new_name
             )
-        success(ctx, f"File renamed from '{old_name}' to '{new_name}' in folder {cmid}.")
+        success(
+            ctx,
+            f"File renamed from '{old_name}' to '{new_name}' in folder {cmid}.",
+        )
     except MoodleFolderError as e:
         error(ctx, f"Error renaming file: {e}")
         raise typer.Exit(1)

--- a/src/py_moodle/cli/modules.py
+++ b/src/py_moodle/cli/modules.py
@@ -5,10 +5,9 @@ from typing import Optional
 import typer
 
 from py_moodle.assign import MoodleAssignError, add_assign
+from py_moodle.cli.feedback import error, status, success, upload_progress, warning
 from py_moodle.cli.output import OutputFormat, emit, render_dry_run_plan
 from py_moodle.label import MoodleLabelError, add_label, update_label
-
-# Import functions from the library directly
 from py_moodle.module import (
     MoodleModuleError,
     delete_module,
@@ -18,17 +17,14 @@ from py_moodle.module import (
 from py_moodle.scorm import MoodleScormError, add_scorm
 from py_moodle.session import MoodleSession
 
-# --- Main app for the "modules" command ---
 app = typer.Typer(
     help="Manage course modules (resources/activities) like labels, SCORMs, etc.",
     no_args_is_help=True,
 )
 
-# --- Sub-app for the "add" command ---
 add_app = typer.Typer(help="Add a new module to a course.", no_args_is_help=True)
 app.add_typer(add_app, name="add")
 
-# --- Sub-app for the "edit" command ---
 edit_app = typer.Typer(
     help="Edit existing course modules (labels, SCORMs, etc.)", no_args_is_help=True
 )
@@ -40,23 +36,20 @@ def delete_a_module(
     ctx: typer.Context,
     cmid: int = typer.Argument(..., help="ID of the module (cmid) to delete."),
 ):
-    """
-    Deletes any module (label, SCORM, folder, etc.) by its ID.
-    This uses the centralized delete function from the library.
-    """
+    """Delete any module by its course module ID."""
     ms = MoodleSession.get(ctx.obj["env"])
 
-    typer.echo(f"This will delete the module with cmid={cmid}")
+    warning(ctx, f"This will delete the module with cmid={cmid}.")
     if not typer.confirm("Are you sure? This action cannot be undone."):
-        typer.echo("Operation cancelled.")
+        warning(ctx, "Operation cancelled.")
         raise typer.Exit()
 
     try:
-        # The delete function is already centralized, no changes needed.
-        delete_module(ms.session, ms.settings.url, ms.sesskey, cmid)
-        typer.echo(f"Module {cmid} deleted successfully.")
+        with status(ctx, f"Deleting module {cmid}..."):
+            delete_module(ms.session, ms.settings.url, ms.sesskey, cmid)
+        success(ctx, f"Module {cmid} deleted successfully.")
     except MoodleModuleError as e:
-        typer.echo(f"Error deleting module: {e}", err=True)
+        error(ctx, f"Error deleting module: {e}")
         raise typer.Exit(1)
 
 
@@ -68,13 +61,11 @@ def show_a_module(
         OutputFormat.TABLE, "--output", help="Output format: table, json, or yaml."
     ),
 ):
-    """
-    Shows detailed information for a specific module.
-    """
+    """Show detailed information for a specific module."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        # This function is also generic and doesn't need changes.
-        module_info = get_module_info(ms.session, ms.settings.url, ms.sesskey, cmid)
+        with status(ctx, f"Fetching module {cmid}...", output):
+            module_info = get_module_info(ms.session, ms.settings.url, ms.sesskey, cmid)
 
         def _render_table(data):
             typer.echo(format_module_table(data))
@@ -82,11 +73,8 @@ def show_a_module(
         emit(module_info, output, table_fn=_render_table)
 
     except MoodleModuleError as e:
-        typer.echo(f"Error getting module info: {e}", err=True)
+        error(ctx, f"Error getting module info: {e}")
         raise typer.Exit(1)
-
-
-# --- Specific commands under "add" ---
 
 
 @add_app.command("label")
@@ -103,26 +91,22 @@ def add_a_label_cmd(
         "Label (from CLI)", "--name", help="Internal name for the label."
     ),
 ):
-    """
-    Adds a new label to a course section.
-    """
+    """Add a new label to a course section."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        # --- KEY CHANGE ---
-        # No longer calling a generic 'add_module' from the CLI.
-        # Directly invoking the 'add_label' function from the library.
-        new_cmid = add_label(
-            session=ms.session,
-            base_url=ms.settings.url,
-            sesskey=ms.sesskey,
-            course_id=course_id,
-            section_id=section_id,
-            html=html,
-            name=name,
-        )
-        typer.echo(f"Label created successfully. New module ID (cmid): {new_cmid}")
-    except MoodleLabelError as e:  # We use the module-specific error
-        typer.echo(f"Error creating label: {e}", err=True)
+        with status(ctx, "Creating label..."):
+            new_cmid = add_label(
+                session=ms.session,
+                base_url=ms.settings.url,
+                sesskey=ms.sesskey,
+                course_id=course_id,
+                section_id=section_id,
+                html=html,
+                name=name,
+            )
+        success(ctx, f"Label created. New module ID (cmid): {new_cmid}")
+    except MoodleLabelError as e:
+        error(ctx, f"Error creating label: {e}")
         raise typer.Exit(1)
 
 
@@ -151,9 +135,7 @@ def add_a_scorm_cmd(
         help="Preview the SCORM package that would be added without uploading it.",
     ),
 ):
-    """
-    Adds a new SCORM package to a course section.
-    """
+    """Add a new SCORM package to a course section."""
     if dry_run:
         plan = {
             "action": "add_scorm",
@@ -170,21 +152,22 @@ def add_a_scorm_cmd(
 
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        new_cmid = add_scorm(
-            session=ms.session,
-            base_url=ms.settings.url,
-            sesskey=ms.sesskey,
-            course_id=course_id,
-            section_id=section_id,
-            name=name,
-            file_path=file_path.name,  # .name to get the file path
-            intro=intro,
-        )
-        typer.echo(
-            f"SCORM package added successfully. New module ID (cmid): {new_cmid}"
-        )
-    except MoodleScormError as e:  # We use the module-specific error
-        typer.echo(f"Error adding SCORM package: {e}", err=True)
+        with upload_progress(ctx, file_path.name, output_format=output) as progress_callback:
+            new_cmid = add_scorm(
+                session=ms.session,
+                base_url=ms.settings.url,
+                sesskey=ms.sesskey,
+                course_id=course_id,
+                section_id=section_id,
+                name=name,
+                file_path=file_path.name,
+                intro=intro,
+                progress_callback=progress_callback,
+            )
+        if output == OutputFormat.TABLE:
+            success(ctx, f"SCORM package added. New module ID (cmid): {new_cmid}")
+    except MoodleScormError as e:
+        error(ctx, f"Error adding SCORM package: {e}")
         raise typer.Exit(1)
 
 
@@ -204,31 +187,26 @@ def add_an_assign_cmd(
         help="Introduction or description for the assignment (HTML supported).",
     ),
 ):
-    """
-    Adds a new assignment to a course section.
-    """
+    """Add a new assignment to a course section."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        new_cmid = add_assign(
-            session=ms.session,
-            base_url=ms.settings.url,
-            sesskey=ms.sesskey,
-            course_id=course_id,
-            section_id=section_id,
-            name=name,
-            intro=intro,
-        )
-        typer.echo(
-            f"Assignment '{name}' created successfully. New module ID (cmid): {new_cmid}"
+        with status(ctx, "Creating assignment..."):
+            new_cmid = add_assign(
+                session=ms.session,
+                base_url=ms.settings.url,
+                sesskey=ms.sesskey,
+                course_id=course_id,
+                section_id=section_id,
+                name=name,
+                intro=intro,
+            )
+        success(
+            ctx,
+            f"Assignment '{name}' created. New module ID (cmid): {new_cmid}",
         )
     except MoodleAssignError as e:
-        typer.echo(f"Error creating assignment: {e}", err=True)
+        error(ctx, f"Error creating assignment: {e}")
         raise typer.Exit(1)
-
-
-# UPDATED NOTE: To add support for "folder" or "file":
-# 1. Create the `add_folder`, `add_file` functions in the library, following the pattern of calling `add_generic_module`.
-# 2. Add a new command here: `@add_app.command("folder")` that calls `add_folder`.
 
 
 @edit_app.command("label")
@@ -236,7 +214,7 @@ def edit_a_label(
     ctx: typer.Context,
     cmid: int = typer.Argument(..., help="ID of the label module to edit."),
     html: Optional[str] = typer.Option(
-        None, "--html", help="New HTML content for the label."
+        None, "--html", help="New HTML content of the label."
     ),
     name: Optional[str] = typer.Option(
         None, "--name", help="New internal name for the label."
@@ -245,30 +223,27 @@ def edit_a_label(
         None, "--visible", help="Set visibility (1 for visible, 0 for hidden)."
     ),
 ):
-    """
-    Edits an existing label module.
-    """
+    """Edit an existing label module."""
     ms = MoodleSession.get(ctx.obj["env"])
 
     if all(opt is None for opt in [html, name, visible]):
-        typer.echo(
-            "Nothing to update. Please provide at least one option to change (e.g., --html)."
-        )
+        warning(ctx, "Nothing to update. Provide at least one option to change.")
         raise typer.Exit()
 
     try:
-        success = update_label(
-            session=ms.session,
-            base_url=ms.settings.url,
-            cmid=cmid,
-            html=html,
-            name=name,
-            visible=visible,
-        )
-        if success:
-            typer.echo(f"Label {cmid} updated successfully.")
+        with status(ctx, f"Updating label {cmid}..."):
+            updated = update_label(
+                session=ms.session,
+                base_url=ms.settings.url,
+                cmid=cmid,
+                html=html,
+                name=name,
+                visible=visible,
+            )
+        if updated:
+            success(ctx, f"Label {cmid} updated successfully.")
     except MoodleLabelError as e:
-        typer.echo(f"Error updating label: {e}", err=True)
+        error(ctx, f"Error updating label: {e}")
         raise typer.Exit(1)
 
 
@@ -284,20 +259,18 @@ def list_available_module_types(
         OutputFormat.TABLE, "--output", help="Output format: table, json, or yaml."
     ),
 ):
-    """
-    Lists all available module types (activities/resources) that can be added to a course.
-    """
+    """List module types that can be added to a course."""
     ms = MoodleSession.get(ctx.obj["env"])
 
     try:
-        from rich.console import Console
         from rich.table import Table
 
         from py_moodle.module import get_module_types
 
-        module_types = get_module_types(
-            ms.session, ms.settings.url, ms.sesskey, course_id
-        )
+        with status(ctx, "Fetching available module types...", output):
+            module_types = get_module_types(
+                ms.session, ms.settings.url, ms.sesskey, course_id
+            )
 
         def _render_table(data):
             table = Table(
@@ -316,12 +289,14 @@ def list_available_module_types(
                     module.get("title"),
                 )
 
-            Console().print(table)
+            from py_moodle.cli.output import get_console
+
+            get_console(ctx).print(table)
 
         emit(module_types, output, table_fn=_render_table)
 
     except MoodleModuleError as e:
-        typer.echo(f"Error listing module types: {e}", err=True)
+        error(ctx, f"Error listing module types: {e}")
         raise typer.Exit(1)
 
 
@@ -336,26 +311,25 @@ def edit_module_name(
         help="The new name for the module.",
     ),
 ):
-    """
-    Edits the name of any module (label, assign, SCORM, etc.).
-    """
+    """Edit the name of any module."""
     ms = MoodleSession.get(ctx.obj["env"])
 
     try:
         from py_moodle.module import rename_module_name
 
-        success = rename_module_name(
-            session=ms.session,
-            base_url=ms.settings.url,
-            sesskey=ms.sesskey,
-            cmid=cmid,
-            name=name,
-        )
-        if success:
-            typer.echo(f"Module {cmid} renamed successfully to '{name}'.")
+        with status(ctx, f"Renaming module {cmid}..."):
+            renamed = rename_module_name(
+                session=ms.session,
+                base_url=ms.settings.url,
+                sesskey=ms.sesskey,
+                cmid=cmid,
+                name=name,
+            )
+        if renamed:
+            success(ctx, f"Module {cmid} renamed successfully to '{name}'.")
 
     except MoodleModuleError as e:
-        typer.echo(f"Error renaming module: {e}", err=True)
+        error(ctx, f"Error renaming module: {e}")
         raise typer.Exit(1)
 
 

--- a/src/py_moodle/cli/modules.py
+++ b/src/py_moodle/cli/modules.py
@@ -152,7 +152,9 @@ def add_a_scorm_cmd(
 
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        with upload_progress(ctx, file_path.name, output_format=output) as progress_callback:
+        with upload_progress(
+            ctx, file_path.name, output_format=output
+        ) as progress_callback:
             new_cmid = add_scorm(
                 session=ms.session,
                 base_url=ms.settings.url,

--- a/src/py_moodle/cli/resources.py
+++ b/src/py_moodle/cli/resources.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from py_moodle.cli.feedback import error, success, upload_progress
 from py_moodle.resource import MoodleResourceError, add_resource, delete_resource
 from py_moodle.session import MoodleSession
 
@@ -31,21 +32,21 @@ def add_a_resource(
     """Add a new resource (single file) to a course section."""
     ms = MoodleSession.get(ctx.obj["env"])
     try:
-        new_cmid = add_resource(
-            session=ms.session,
-            base_url=ms.settings.url,
-            sesskey=ms.sesskey,
-            course_id=course_id,
-            section_id=section_id,
-            name=name,
-            file_path=file.name,
-            intro=intro,
-        )
-        typer.echo(
-            f"Resource '{name}' created successfully. New module ID (cmid): {new_cmid}"
-        )
+        with upload_progress(ctx, file.name) as progress_callback:
+            new_cmid = add_resource(
+                session=ms.session,
+                base_url=ms.settings.url,
+                sesskey=ms.sesskey,
+                course_id=course_id,
+                section_id=section_id,
+                name=name,
+                file_path=file.name,
+                intro=intro,
+                progress_callback=progress_callback,
+            )
+        success(ctx, f"Resource '{name}' created. New module ID (cmid): {new_cmid}")
     except MoodleResourceError as e:
-        typer.echo(f"Error creating resource: {e}", err=True)
+        error(ctx, f"Error creating resource: {e}")
         raise typer.Exit(1)
 
 
@@ -66,9 +67,9 @@ def delete_a_resource(
         )
     try:
         delete_resource(ms.session, ms.settings.url, ms.sesskey, cmid)
-        typer.echo(f"Resource {cmid} deleted successfully.")
+        success(ctx, f"Resource {cmid} deleted successfully.")
     except MoodleResourceError as e:
-        typer.echo(f"Error deleting resource: {e}", err=True)
+        error(ctx, f"Error deleting resource: {e}")
         raise typer.Exit(1)
 
 

--- a/tests/unit/test_cli_rich_feedback.py
+++ b/tests/unit/test_cli_rich_feedback.py
@@ -1,0 +1,96 @@
+"""Unit tests for Rich CLI feedback and upload progress."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import typer
+from rich.console import Console
+
+from py_moodle.cli.feedback import error, status, success, upload_progress, warning
+from py_moodle.cli.output import OutputFormat
+
+
+def _ctx(*, quiet: bool = False, no_color: bool = True) -> typer.Context:
+    """Build a minimal Typer context for feedback helper tests."""
+    ctx = MagicMock(spec=typer.Context)
+    ctx.obj = {"quiet": quiet, "no_color": no_color}
+    return ctx
+
+
+def test_success_and_warning_respect_quiet(monkeypatch):
+    """Incidental success and warning messages are suppressed by --quiet."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, no_color=True)
+    monkeypatch.setattr("py_moodle.cli.feedback.get_console", lambda ctx=None: console)
+
+    ctx = _ctx(quiet=True)
+    success(ctx, "Created")
+    warning(ctx, "Skipped")
+
+    assert buffer.getvalue() == ""
+
+
+def test_error_is_never_suppressed(monkeypatch, capsys):
+    """Errors remain visible on stderr even when --quiet is active."""
+    console = Console(force_terminal=False, no_color=True)
+    monkeypatch.setattr("py_moodle.cli.feedback.get_console", lambda ctx=None: console)
+
+    error(_ctx(quiet=True), "Upload failed")
+
+    captured = capsys.readouterr()
+    assert "Upload failed" in captured.err
+    assert captured.out == ""
+
+
+def test_status_is_noop_for_machine_readable_output(monkeypatch):
+    """JSON/YAML/CSV paths never render Rich status output."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=True, no_color=True)
+    monkeypatch.setattr("py_moodle.cli.feedback.get_console", lambda ctx=None: console)
+
+    for output_format in (OutputFormat.JSON, OutputFormat.YAML, OutputFormat.CSV):
+        with status(_ctx(), "Fetching...", output_format):
+            pass
+
+    assert buffer.getvalue() == ""
+
+
+def test_upload_progress_is_noop_for_machine_readable_output(monkeypatch):
+    """Machine-readable output receives a safe callback without terminal output."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=True, no_color=True)
+    monkeypatch.setattr("py_moodle.cli.feedback.get_console", lambda ctx=None: console)
+
+    with upload_progress(
+        _ctx(),
+        "/path/does/not/need/to/exist.zip",
+        output_format=OutputFormat.JSON,
+    ) as callback:
+        callback(1024)
+
+    assert buffer.getvalue() == ""
+
+
+def test_upload_progress_renders_byte_progress(monkeypatch, tmp_path):
+    """Interactive table output renders a byte-based Rich progress bar."""
+    upload = tmp_path / "package.zip"
+    upload.write_bytes(b"x" * 2048)
+
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        no_color=True,
+        width=120,
+    )
+    monkeypatch.setattr("py_moodle.cli.feedback.get_console", lambda ctx=None: console)
+
+    with upload_progress(_ctx(), str(upload)) as callback:
+        callback(1024)
+        callback(1024)
+
+    rendered = buffer.getvalue()
+    assert "Uploading package.zip" in rendered
+    assert "100%" in rendered


### PR DESCRIPTION
## Summary

- add centralized Rich helpers for `success()`, `warning()`, `error()`, `status()`, and byte-based upload progress
- show upload progress for SCORM packages, resources, folder files, and multi-file folder creation
- show Rich status spinners for slow operations that do not expose measurable progress
- suppress progress/status for `--quiet`, non-interactive output, and machine-readable JSON/YAML/CSV paths
- keep the existing `emit()` implementation and JSON/YAML/CSV serializers unchanged
- add unit tests covering quiet/error behavior, machine-readable output suppression, and byte-progress rendering

## Notes

Progress is driven by the existing `progress_callback` hooks in the library layer, so this change does not alter the public upload APIs.

## Testing

- added `tests/unit/test_cli_rich_feedback.py`
- existing output-format tests remain unchanged
