### PR TITLE
Add Python 3.14 support and Python 3.15 pre-release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15']
 
     steps:
       - name: Checkout code
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: 'pip'
 
       - name: Install dependencies
@@ -92,7 +93,7 @@ jobs:
             moodle-label: Moodle 5.0.1
             moodle-cache-key: moodle-5-0-1
             run-examples: true
-          - python-version: '3.13'
+          - python-version: '3.14'
             moodle-image: erseco/alpine-moodle:v5.1.5
             moodle-label: Moodle 5.1.5
             moodle-cache-key: moodle-5-1-5

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # python-moodle
 
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/erseco/python-moodle/blob/main/LICENSE)
-[![Python Version](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.9%20to%203.14-blue.svg)](https://www.python.org/downloads/)
 [![CI](https://github.com/erseco/python-moodle/actions/workflows/ci.yml/badge.svg)](https://github.com/erseco/python-moodle/actions/workflows/ci.yml)
 [![PyPI downloads](https://img.shields.io/pypi/dm/python-moodle)](https://pypi.org/project/python-moodle/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -19,7 +19,7 @@
 - **Works with web sessions** — simulates a real user browser session, no Moodle plugins needed
 - **CLI for admins** and **library for automation scripts**
 - **Handles courses, sections, labels, folders, assignments and SCORM** out of the box
-- **Tested against Moodle 4.x and 5.x** on Python 3.8–3.13
+- **Tested against Moodle 4.x and 5.x** on supported Python 3.9–3.14 releases, with Python 3.15 pre-releases validated in CI
 
 ### python-moodle vs. Moodle webservice wrappers
 
@@ -90,7 +90,7 @@ At the moment, representative compatibility handling has been wired into login/s
 
 ## Installation
 
-You will need Python 3.8+ and `pip`.
+You will need Python 3.9+ and `pip`. Stable support currently covers Python 3.9–3.14; Python 3.15 pre-releases are continuously tested in CI ahead of the final release.
 
 ### Install from PyPI (Recommended)
 
@@ -281,12 +281,12 @@ make test
 
 GitHub Actions automatically runs:
 
-- linting on Python 3.13
-- smoke tests on Python 3.9 through 3.13
+- linting on Python 3.14
+- smoke tests on supported Python 3.9 through 3.14, plus Python 3.15 pre-releases
 - Docker-backed integration tests on representative Python/Moodle combinations:
   - Python 3.9 with Moodle 4.5.5
   - Python 3.13 with Moodle 5.0.1
-  - Python 3.13 with Moodle 5.1.5
+  - Python 3.14 with Moodle 5.1.5
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Education",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration",


### PR DESCRIPTION
## Summary

- declare Python 3.14 support in package classifiers
- run linting on Python 3.14
- extend unit-test coverage through Python 3.14
- add Python 3.15 pre-release validation in CI via `allow-prereleases: true`
- run the latest Moodle 5.1.5 integration leg on Python 3.14
- align the README with the actual `requires-python >=3.9` policy
- document Python 3.9–3.14 as stable support and Python 3.15 as pre-release CI coverage

## Compatibility policy

- **Stable support:** Python 3.9–3.14
- **Pre-release validation:** Python 3.15

Python 3.15 is intentionally not added as a PyPI classifier yet because it has not reached its final release.

## Scope

This PR only updates CI and compatibility metadata/documentation. It does not change library or CLI behavior.