### PR TITLE
Reduce flaky Moodle integration test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,45 @@ jobs:
         run: MOODLE_DOCKER_IMAGE="${{ matrix.moodle-image }}" make upd
 
       - name: Run tests
-        run: make test-local
+        run: |
+          set -uo pipefail
+          max_attempts=2
+          retry_delay=15
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            log_file="$(mktemp)"
+            make test-local 2>&1 | tee "$log_file"
+            test_status=${PIPESTATUS[0]}
+
+            if [ "$test_status" -eq 0 ]; then
+              rm -f "$log_file"
+              exit 0
+            fi
+
+            known_race=0
+            if grep -Fq 'duplicate key value violates unique constraint "mdl_cont_conins_uix"' "$log_file"; then
+              known_race=1
+            fi
+            if grep -Fq "Can't find data record in database table course" "$log_file"; then
+              known_race=1
+            fi
+
+            if [ "$known_race" -ne 1 ]; then
+              echo "Integration tests failed for a non-flaky reason; not retrying."
+              rm -f "$log_file"
+              exit "$test_status"
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "Known Moodle race persisted after $max_attempts attempts."
+              rm -f "$log_file"
+              exit "$test_status"
+            fi
+
+            echo "Known Moodle database race detected; retrying in ${retry_delay}s..."
+            rm -f "$log_file"
+            sleep "$retry_delay"
+          done
 
       - name: Run example_script.py
         if: matrix.run-examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,16 @@ jobs:
       - name: Run tests
         run: |
           set -uo pipefail
-          max_attempts=2
-          retry_delay=15
+          max_attempts=3
 
           for attempt in $(seq 1 "$max_attempts"); do
+            echo "Moodle integration attempt ${attempt}/${max_attempts}"
             log_file="$(mktemp)"
-            make test-local 2>&1 | tee "$log_file"
+
+            set +e
+            make test-local-ci 2>&1 | tee "$log_file"
             test_status=${PIPESTATUS[0]}
+            set -e
 
             if [ "$test_status" -eq 0 ]; then
               rm -f "$log_file"
@@ -165,9 +168,10 @@ jobs:
               exit "$test_status"
             fi
 
-            echo "Known Moodle database race detected; retrying in ${retry_delay}s..."
+            echo "Known Moodle database race detected. Resetting Moodle before retry..."
             rm -f "$log_file"
-            sleep "$retry_delay"
+            docker compose down -v
+            MOODLE_DOCKER_IMAGE="${{ matrix.moodle-image }}" make upd
           done
 
       - name: Run example_script.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ENV_FILE=.env
 
-.PHONY: ensure-env check-docker up format lint docs docs-generate test test-unit test-local test-staging
+.PHONY: ensure-env check-docker up format lint docs docs-generate test test-unit test-local test-local-ci test-staging
 
 ensure-env:
 	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
@@ -54,6 +54,9 @@ test-unit:
 test-local: ensure-env
 	pytest --integration --moodle-env local -m integration -n auto --dist loadfile
 
+test-local-ci: ensure-env
+	pytest --integration --moodle-env local -m integration
+
 test-staging: ensure-env
 	pytest --integration --moodle-env staging -m integration -n auto --dist loadfile
 
@@ -79,8 +82,9 @@ help:
 	@echo ""
 	@echo "Testing:"
 	@echo "  test-unit          - Run fast smoke tests that do not require Moodle"
-	@echo "  test-local         - Run local tests (parallel by file) using pytest with moodle-env=local"
-	@echo "  test-staging       - Run tests (parallel by file) using moodle-env=staging"
+	@echo "  test-local         - Run local tests (parallel by file) using moodle-env=local"
+	@echo "  test-local-ci      - Run local Moodle integration tests serially for CI stability"
+	@echo "  test-staging       - Run staging tests (parallel by file) using moodle-env=staging"
 	@echo "  test               - Start containers (detached) and run local tests"
 	@echo ""
 	@echo "  help               - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ test-unit:
 	pytest tests/unit
 
 test-local: ensure-env
-	pytest --integration --moodle-env local -m integration -n auto
+	pytest --integration --moodle-env local -m integration -n auto --dist loadfile
 
 test-staging: ensure-env
-	pytest --integration --moodle-env staging -m integration -n auto
+	pytest --integration --moodle-env staging -m integration -n auto --dist loadfile
 
 test: upd test-local
 
@@ -64,7 +64,7 @@ help:
 	@echo ""
 	@echo "Environment:"
 	@echo "  ensure-env         - Create .env file from .env.example if it does not exist"
-	@echo "  check-docker       - Check if Docker is running"
+	@echo "  check-docker       - Check if Docker is running. Please ensure Docker is installed and running."
 	@echo ""
 	@echo "Startup:"
 	@echo "  up                 - Run Docker containers in foreground mode"
@@ -79,8 +79,8 @@ help:
 	@echo ""
 	@echo "Testing:"
 	@echo "  test-unit          - Run fast smoke tests that do not require Moodle"
-	@echo "  test-local         - Run local tests (in parallel) using pytest with moodle-env=local"
-	@echo "  test-staging       - Run tests (in parallel) using moodle-env=staging"
+	@echo "  test-local         - Run local tests (parallel by file) using pytest with moodle-env=local"
+	@echo "  test-staging       - Run tests (parallel by file) using moodle-env=staging"
 	@echo "  test               - Start containers (detached) and run local tests"
 	@echo ""
 	@echo "  help               - Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ help:
 	@echo ""
 	@echo "Environment:"
 	@echo "  ensure-env         - Create .env file from .env.example if it does not exist"
-	@echo "  check-docker       - Check if Docker is running. Please ensure Docker is installed and running."
+	@echo "  check-docker       - Check if Docker is running"
 	@echo ""
 	@echo "Startup:"
 	@echo "  up                 - Run Docker containers in foreground mode"


### PR DESCRIPTION
## Summary

- run Moodle integration tests serially in CI to remove cross-file races against one shared Moodle instance
- keep parallel-by-file integration execution available for local development
- retry the CI integration suite up to three attempts only for known Moodle database-race signatures
- reset Moodle and PostgreSQL, including the database volume, before each retry
- preserve immediate failure for assertions and unknown errors
- explicitly handle GitHub Actions' default `bash -e -o pipefail` behavior so a failed pytest attempt can actually reach the retry logic

## Root cause

The recent failures are non-deterministic Moodle-side races triggered by concurrent integration tests sharing one Moodle database. We have observed both:

- `duplicate key value violates unique constraint "mdl_cont_conins_uix"`
- `Can't find data record in database table course`

A rerun of the same CI jobs has passed without code changes, which confirms the failures are flaky rather than deterministic regressions.

The existing cross-process course-creation lock is not sufficient because tests in different files can still create/delete Moodle modules and temporary courses concurrently. That can race with other workers listing courses or creating Moodle contexts.

## CI strategy

CI now uses `make test-local-ci`, which runs the Moodle integration suite serially. Local `make test-local` and `make test-staging` retain pytest-xdist parallelism with `--dist loadfile` for faster development runs.

If a serial CI run still fails with one of the known Moodle race signatures, CI performs at most three total attempts. Before the next attempt it runs `docker compose down -v` and starts the selected Moodle image again, giving the retry a fresh PostgreSQL database and Moodle state.

## Retry safety

Retries are deliberately narrow. Normal test failures, assertion failures, and unknown exceptions are not retried and still fail the job immediately.

## Scope

This PR changes only integration-test scheduling and CI retry behavior; it does not change library or CLI code.